### PR TITLE
Public reorg

### DIFF
--- a/source/howto/zephyr-mcuboot-keys.rst
+++ b/source/howto/zephyr-mcuboot-keys.rst
@@ -77,12 +77,12 @@ The important files this generates (when combined with the previous
 steps) are:
 
 - A custom MCUboot binary which trusts your public key in
-  :file:`outdir/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/mcuboot/zephyr/zephyr.bin`. Use
+  :file:`build/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/mcuboot/zephyr/zephyr.bin`. Use
   this binary when flashing devices you are going to deploy to the
   field.
 
 - A Zephyr binary which is signed with your private key in
-  :file:`outdir/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/app/zephyr/dm-lwm2m-nrf52_blenano2-signed.bin`. You
+  :file:`build/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/app/zephyr/dm-lwm2m-nrf52_blenano2-signed.bin`. You
   can distribute this binary in FOTA updates.
 
 To verify your setup, flash the custom MCUboot to your board, along

--- a/source/other/hawkbit-mqtt-system.rst
+++ b/source/other/hawkbit-mqtt-system.rst
@@ -293,7 +293,7 @@ microPlatform installation directory:
 
          python zephyr-fota-samples/dm-hawkbit-mqtt/scripts/hawkbit.py \
                            -d 'BLE Nano 2 Update' \
-                           -f outdir/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52_blenano2/app/zephyr/dm-hawkbit-mqtt-nrf52_blenano2-signed.bin \
+                           -f build/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52_blenano2/app/zephyr/dm-hawkbit-mqtt-nrf52_blenano2-signed.bin \
                            -sv "1.0" -p "Testing" -n "nrf52_blenano2 update" -t os
 
    .. tab-container:: nrf52_pca10040
@@ -303,7 +303,7 @@ microPlatform installation directory:
 
          python zephyr-fota-samples/dm-hawkbit-mqtt/scripts/hawkbit.py \
                            -d 'nRF52 DK Update' \
-                           -f outdir/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52_pca10040/app/zephyr/dm-hawkbit-mqtt-nrf52_pca10040-signed.bin \
+                           -f build/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52_pca10040/app/zephyr/dm-hawkbit-mqtt-nrf52_pca10040-signed.bin \
                            -sv "1.0" -p "Testing" -n "nrf52_pca10040 update" -t os
 
    .. tab-container:: nrf52840_pca10056
@@ -313,7 +313,7 @@ microPlatform installation directory:
 
          python zephyr-fota-samples/dm-hawkbit-mqtt/scripts/hawkbit.py \
                            -d 'nRF52840 DK Update' \
-                           -f outdir/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52840_pca10056/app/zephyr/dm-hawkbit-mqtt-nrf52840_pca10056-signed.bin \
+                           -f build/zephyr-fota-samples/dm-hawkbit-mqtt/nrf52840_pca10056/app/zephyr/dm-hawkbit-mqtt-nrf52840_pca10056-signed.bin \
                            -sv "1.0" -p "Testing" -n "nrf52840_pca10056 update" -t os
 
 Above, 1.0 is an arbitrary version number. If hawkBit is running on a

--- a/source/reference/zephyr-zmp.rst
+++ b/source/reference/zephyr-zmp.rst
@@ -3,6 +3,17 @@
 Zephyr microPlatform zmp Tool
 =============================
 
+.. important::
+
+   The ``zmp`` tool was developed because of perceived complexity in
+   Zephyr's building and flashing tools.
+
+   Foundries.io has been working with upstream Zephyr to move many of
+   zmp's features -- such as flashing and debugging with command line
+   options and arguments -- upstream into the "west" tool.
+
+   When this task is finished, ``zmp`` will be replaced with west.
+
 This page describes a helper script, ``zmp``, provided by the Zephyr
 microPlatform. ``zmp`` provides a higher-level interface to the Zephyr
 and MCUboot build systems, which is optional, but can be easier to use.
@@ -37,7 +48,7 @@ To get help, run this from the Zephyr microPlatform root directory::
 
 The ``zmp build`` command always builds out of tree; that is,
 build artifacts are never generated in the source code directories. By
-default, they are stored under ``outdir`` in the Zephyr microPlatform top-level
+default, they are stored under ``build`` in the Zephyr microPlatform top-level
 directory.
 
 Examples:
@@ -48,9 +59,9 @@ Examples:
 
       ./zmp build -b nrf52_blenano2 zephyr/samples/hello_world
 
-  This generates artifacts under ``outdir`` like so::
+  This generates artifacts under ``build`` like so::
 
-    outdir/
+    build/
     └── zephyr
         └── samples
             └── hello_world
@@ -59,7 +70,7 @@ Examples:
                     └── mcuboot
 
   The application build for ``nrf52_blenano2`` is in
-  ``outdir/zephyr/samples/hello_world/nrf52_blenano2/app``. The
+  ``build/zephyr/samples/hello_world/nrf52_blenano2/app``. The
   MCUboot build is in ``mcuboot``, next to ``app``.
 
 - To build the same application for another board,
@@ -73,7 +84,7 @@ Examples:
   Running this after building for BLE Nano 2 as in the above
   example results in a parallel set of build artifacts, like so::
 
-    outdir/
+    build/
     └── zephyr
         └── samples
             └── hello_world

--- a/source/tutorial/basic-system.rst
+++ b/source/tutorial/basic-system.rst
@@ -175,7 +175,7 @@ microPlatform binary build directory for your board:
 
       .. code-block:: console
 
-         cd outdir/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/app/
+         cd build/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2/app/
          python3 -m http.server
 
       The update will then be available at::
@@ -187,7 +187,7 @@ microPlatform binary build directory for your board:
 
       .. code-block:: console
 
-         cd outdir/zephyr-fota-samples/dm-lwm2m/nrf52_pca10040/app/
+         cd build/zephyr-fota-samples/dm-lwm2m/nrf52_pca10040/app/
          python3 -m http.server
 
       The update will then be available at::
@@ -199,7 +199,7 @@ microPlatform binary build directory for your board:
 
       .. code-block:: console
 
-         cd outdir/zephyr-fota-samples/dm-lwm2m/nrf52840_pca10056/app/
+         cd build/zephyr-fota-samples/dm-lwm2m/nrf52840_pca10056/app/
          python3 -m http.server
 
       The update will then be available at::

--- a/source/tutorial/basic-system.rst
+++ b/source/tutorial/basic-system.rst
@@ -98,16 +98,25 @@ Use the System
 --------------
 
 Now that your system is fully set up, it's time to check that sensor
-data are being sent to the cloud, and do a FOTA update. Your device
-should be connecting to https://mgmt.foundries.io/leshan/ via the
-containers running on the gateway now.
+data are being sent to the cloud, and do a FOTA update.
+
+Look in your IoT device console for a log line ending in something
+like this:
+
+.. code-block:: none
+
+   LWM2M Endpoint Client Name: zmp:sn:deadbeef
+
+Above, the value ``zmp:sn:deadbeef`` is your device's client ID, which
+it uses to register with the LWM2M server. Look for that ID in the
+clients list at https://mgmt.foundries.io/leshan/#/clients, and click
+on it to view available LWM2M objects on your device.
 
 .. note::
 
-   The Leshan user web interface is a simple web application, which
-   does not provide a complete end-to-end device management system.
-   The container's simplicity makes it useful as a demonstration and
-   prototyping system for LWM2M devices.
+   This LWM2M server interface is provided by Foundries.io only for
+   ease of use bringing up the system and prototyping. Availability
+   etc. are not guaranteed.
 
 Read and Write Objects
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tutorial/dtls-system.rst
+++ b/source/tutorial/dtls-system.rst
@@ -56,7 +56,7 @@ Again from the ZMP installation directory, you now need to re-build
 and re-flash the application with DTLS enabled, along with the
 credentials partition::
 
-  rm -rf outdir/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2
+  rm -rf build/zephyr-fota-samples/dm-lwm2m/nrf52_blenano2
   ./zmp build --overlay-config=overlay-dtls.conf zephyr-fota-samples/dm-lwm2m
   ./zmp flash -b nrf52_blenano2 zephyr-fota-samples/dm-lwm2m
   pyocd-flashtool -se -t nrf52 --address 0x7f000 cred.bin


### PR DESCRIPTION
A few tweaks related to zmp changes being made since going public in other repositories (https://github.com/foundriesio/zmp-build/pull/2)

- the default build directory is now `build`, not `outdir`
- lwm2m devices use zmp:xx:yyyy when registering with mgmt.foundries.io
- other miscellany