### PR TITLE
extensions/rpi3: use mp version for github artifacts

### DIFF
--- a/extensions/rpi3.py
+++ b/extensions/rpi3.py
@@ -15,7 +15,7 @@ class LmpRPi3LinksDirective(core.Directive):
         config = self.get_config()
 
         def art_ref(artifact):
-            url = linux_github_artifact(config.lmp_build, artifact)
+            url = linux_github_artifact(config.mp_version, artifact)
             return self.build_link(url, url)
 
         # Paragraph linking to the release.

--- a/source/howto/zephyr-boards.rst
+++ b/source/howto/zephyr-boards.rst
@@ -102,7 +102,7 @@ microPlatform-based applications to a new board follow.
   For additional background information on porting MCUBoot to your
   board, see the `MCUBoot README-zephyr.rst`_ file.
 
-.. _Zephyr porting guides: http://docs.zephyrproject.org/latest/porting/porting.html
+.. _Zephyr porting guides: http://docs.zephyrproject.org/latest/porting/index.html
 
 .. _Zephyr networking documentation: http://docs.zephyrproject.org/latest/subsystems/networking/networking.html
 

--- a/source/tutorial/installation-zephyr.rst
+++ b/source/tutorial/installation-zephyr.rst
@@ -457,7 +457,7 @@ with these instructions, which may be useful on other development platforms.
 
 .. _HomeBrew: https://brew.sh/
 
-.. _Zephyr's West tool: http://docs.zephyrproject.org/latest/west/index.html
+.. _Zephyr's West tool: http://docs.zephyrproject.org/latest/tools/west/index.html
 
 .. _Windows Subsystem for Linux: https://docs.microsoft.com/en-us/windows/wsl/about
 


### PR DESCRIPTION
Use the microPlatform version for github artifacts urls.

Signed-off-by: Tyler Baker <tyler@foundries.io>