### PR TITLE
dtls-system: fix build / flash instructions for reel_board

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -125,6 +125,7 @@ linkcheck_ignore = [
     r'https://redbear.cc/product/ble-nano-kit-2.html',  # before deprecating
     r'https://mgmt.foundries.io/leshan/#/clients',  # I have no idea, it works
     r'https://github.com/foundriesio/lmp-manifest/releases/download/.*',  # Release artifacts done show up until *after* this runs
+    'https://mgmt.foundries.io/leshan/#/security',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/tutorial/dtls-system.rst
+++ b/source/tutorial/dtls-system.rst
@@ -62,9 +62,9 @@ Build and Flash IoT Device With DTLS Enabled
 You now need to re-build and re-flash the application with DTLS
 enabled, along with the credentials partition (the location of the
 credentials partition is set by your board's device tree overlay
-file)::
+file). For example, to build for ``reel_board``::
 
-  west build -s zmp-samples/dm-lwm2m -d build-lwm2m-dtls -- -DOVERLAY_CONFIG=overlay-dtls.conf
+  west build --board reel_board -s zmp-samples/dm-lwm2m -d build-dm-lwm2m-dtls -- -DOVERLAY_CONFIG=overlay-dtls.conf
   west sign -t imgtool -d build-dm-lwm2m-dtls -- --key mcuboot/root-rsa-2048.pem
   west flash -d build-dm-lwm2m-dtls --hex-file zephyr.signed.hex
 


### PR DESCRIPTION
This is the simplest for now since pyocd-flashtool (which is now obsolete) can flash the .bin in the right place.

We need to rewrite this to use a west command that generates a .hex instead (not yet available)