### PR TITLE
linux-ota: update need reboot sentinel path

### DIFF
--- a/source/reference/linux-ota.rst
+++ b/source/reference/linux-ota.rst
@@ -172,7 +172,7 @@ yet been rebooted so that the image can become active.
 Automatic Rebooting After Updates
 ---------------------------------
 
-Aktualizr creates an empty file ``/run/aktualizr/ostree-pending-update`` after
+Aktualizr creates an empty file ``/var/run/aktualizr-session/need_reboot`` after
 completing an OSTree update, and a `systemd timer`_ can be defined for the systemd
 service file ``ostree-pending-reboot`` to automatically restart the device once
 there is a pending update.


### PR DESCRIPTION
We now use the aktualizr upstream sentinel file for knowing when the
device needs a reboot, so reflect that in our docs.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>