### PR TITLE
Docs updates

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -144,7 +144,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Foundries.io microPlatforms'
+project = 'FoundriesFactory<sup>&#174;</sup>'
 copyright = '2017-2019, Foundries.io, Ltd'
 author = 'Foundries.io, Ltd.'
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -13,6 +13,7 @@ free on our supported devices, as well as private, customer-owned Factories.
    community-factory/index
    customer-factory/index
    reference/linux
+   foundries.io <https://foundries.io>
 
 .. ifconfig:: todo_include_todos is True
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -2,9 +2,9 @@ FoundriesFactory_ Documentation
 ===============================
 
 The **Linux microPlatform** is a minimal, secure, continuously updated software
-platform. Its built and maintained using the **FoundriesFactory** product.
+platform. It's built and maintained using the **FoundriesFactory** product.
 Foundries.io maintains a community focused Factory that users can try out for
-free on our supported devices as well as private, customer owned Factories.
+free on our supported devices, as well as private, customer-owned Factories.
 
 
 .. toctree::


### PR DESCRIPTION
The third changes, that link to foundries.io website, only works with a recent version of sphinx. I'm not sure which version is being used to build the docs.