### PR TITLE
customer factory: Add note on how to skip CI builds

### DIFF
--- a/source/customer-factory/source-code.rst
+++ b/source/customer-factory/source-code.rst
@@ -55,3 +55,9 @@ any containers defined will be pushed to your factory’s private Docker
 registry at:
 
  https://hub.foundries.io/<myfactory>/<mycontainer>:latest
+
+
+.. note::
+
+   Commit messages that include ``[skip ci]`` or ``[ci skip]`` will not
+   trigger CI builds.


### PR DESCRIPTION
Signed-off-by: Andy Doan <andy@foundries.io>