### PR TITLE
customer-factory: managing: remove aklite restart

### DIFF
--- a/source/customer-factory/managing.rst
+++ b/source/customer-factory/managing.rst
@@ -37,11 +37,6 @@ will register your device(s) via Foundries.io REST API.
 
       Device activation page
 
-#. Once the device has been registered, from a console on the device run the
-   following command::
-
-    sudo systemctl restart aktualizr-lite
-
 #. Now your device is registered, and any new platform builds produced will be
    pushed down to this device, and be applied. You can view all the devices
    registered to your factory at: https://app.foundries.io/devices/. You can


### PR DESCRIPTION
No need to restart aklite service after registration.  It's done
automagically now.

Signed-off-by: Michael Scott <mike@foundries.io>