### PR TITLE
update-the-core: use correct git cmd

### DIFF
--- a/source/customer-factory/updating-the-core.rst
+++ b/source/customer-factory/updating-the-core.rst
@@ -25,5 +25,5 @@ When the new manifest files have been successfully pushed, a new platform build 
 
 If something goes wrong, don’t fret! This is why we use version control!::
 
-  git revert HEAD
+  git reset --hard HEAD~1
   git push


### PR DESCRIPTION
git revert HEAD does not actually do what we say it does.

Signed-off-by: Tyler Baker <tyler@foundries.io>