### PR TITLE
sphinx: add requirements.txt to keep track of dependencies

### DIFF
--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -17,7 +17,7 @@ scripts:
   make-docs: |
     #!/bin/sh -ex
     apk add --update make curl git
-    pip install sphinx_rtd_theme sphinx sphinxcontrib-contentui
+    pip install -r ./requirements.txt
     make OUTDIR=/archive SPHINXBUILD=sphinx-build singlehtml html
 
     urlbase="https://ci.foundries.io/projects/${H_PROJECT}/builds/${H_BUILD}/${H_RUN}/"
@@ -36,5 +36,5 @@ scripts:
   link-check: |
     #!/bin/sh -ex
     apk add --update make git
-    pip install sphinx_rtd_theme sphinx sphinxcontrib-contentui
+    pip install -r ./requirements.txt
     make BUILDDIR=/archive SPHINXBUILD=sphinx-build linkcheck

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx-rtd-theme==0.5.0
 sphinx==3.1.2
 sphinxcontrib-contentui==0.2.5
+sphinx-tabs==1.1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx-rtd-theme==0.5.0
+sphinx==3.1.2
+sphinxcontrib-contentui==0.2.5


### PR DESCRIPTION
Most sphinx projects have a requirements.txt at the root of their doctree to list sphinx extensions and their versions, currently that's just hidden in the form of a pip install command in jobserv that is pasted twice and doesn't have versions for the packages.

Jobserv will now run `pip install -r ./requirements.txt` and if we need to add extensions they'll be added to `requirements.txt` instead of updating the `jobserv.yml`

I've based the versions in requirements.txt on the latest, since that's what I have been using on my machine and seemingly has no regressions in the html output from what I see hosted online now. However, the actual versions that are being used by jobserv are not listed anywhere. 

```
sphinx-rtd-theme==0.5.0
sphinx==3.1.2
sphinxcontrib-contentui==0.2.5
```