### PR TITLE
sphinx: enable sphinx-tab plugin

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -108,6 +108,8 @@ extensions = [
     'sphinx_tabs.tabs',
 ]
 
+sphinx_tabs_valid_builders = ['linkcheck']
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -105,6 +105,7 @@ extensions = [
     'sphinxcontrib.contentui',
     'lmp_sphinx_ext',
     'sphinxemoji.sphinxemoji',
+    'sphinx_tabs.tabs',
 ]
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
Forgot to enable it in #66

This is for fancy tabs that let us handle multiple cases, i.e macos vs win10 vs linux instructions.

![Group Tabs](https://raw.githubusercontent.com/djungelorm/sphinx-tabs/master/images/groupTabs.gif)

Signed-off-by: Matthew Croughan <matthew.croughan@foundries.io>