### PR TITLE
sphinx: limit the page width and also center it

### DIFF
--- a/source/_static/theme_overrides.css
+++ b/source/_static/theme_overrides.css
@@ -12,6 +12,8 @@
    }
 }
 
+/* https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
+/* Center the page and limit width to 1100px */
 @media only screen and (min-width: 769px) {
     .wy-body-for-nav {
         /* Center the page's main pane on wide displays for better readability

--- a/source/_static/theme_overrides.css
+++ b/source/_static/theme_overrides.css
@@ -11,3 +11,26 @@
       overflow: visible !important;
    }
 }
+
+@media only screen and (min-width: 769px) {
+    .wy-body-for-nav {
+        /* Center the page's main pane on wide displays for better readability
+ * */
+        /* `max-width` is (navbar width + main pane width) */
+        max-width: 1100px;
+        margin: 0 auto;
+    }
+}
+
+@media only screen and (min-width: 769px) {
+    .wy-nav-side {
+        /* Required to center the page on wide displays */
+        left: inherit;
+    }
+
+}@media only screen and (min-width: 769px) {
+    .rst-versions {
+        /* Required to center the page on wide displays */
+        left: inherit;
+    }
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -246,6 +246,11 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/source/conf.py
+++ b/source/conf.py
@@ -312,10 +312,3 @@ htmlhelp_basename = 'fiodoc'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
-
-# Enable running conf.py as an extension by adding a setup method
-def setup(app):
-    # RTD theme has a bug:
-    # https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
-    if html_theme == 'sphinx_rtd_theme':
-        app.add_stylesheet('theme_overrides.css')


### PR DESCRIPTION
Currently the docs are a little bit hard to read on a larger monitor, since the docs scale horizontally infinitely and have no limit. As an example I've used @munoz0raul's excellent AWS docs to show the effect this has. This does not effect layouts on smaller screens, it still scales dynamically in that context.

# Before 
![image](https://user-images.githubusercontent.com/26458780/87840674-d1489300-c898-11ea-8e08-9173ec1c9a20.png)

# After
![image](https://user-images.githubusercontent.com/26458780/87840717-03f28b80-c899-11ea-976e-83035754146a.png)
