### PR TITLE
fix compose-apps.rst, doesn't explicitly use python for Dockerfile

### DIFF
--- a/source/reference/compose-apps.rst
+++ b/source/reference/compose-apps.rst
@@ -105,7 +105,7 @@ this scenario containers.git layout might look like::
   FROM alpine
   RUN apk --no-cache add python3
   COPY ./app.py /usr/local/bin
-  CMD ["/usr/local/bin/app.py"]
+  CMD ["python3", "/usr/local/bin/app.py"]
 
 ::
 


### PR DESCRIPTION
Following this guide verbatim leads to an error, since the example py script contains no shebang:
```
create failed: container_linux.go:345: starting container process caused "exec: \"/usr/local/bin/app.py\": permission denied": unknown
```
This example works fine after https://github.com/foundriesio/docs/commit/551bd6eaa3b9612fb7f4d7c29cb9e224ee929d54 and this PR is present.