### PR TITLE
[WIP] getting-started: create-compose-app

### DIFF
--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -35,7 +35,7 @@ Default Example
    When changes are made to ``containers.git`` in your Factory sources, a new target is
    built by our CI system. Devices that are registered to your Factory will be
    able to see this target and conditionally update to it, depending on their
-   device configuration.
+   :ref:`device configuration <ref-configuring-devices>`.
 
 Device Configuration
 --------------------

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -53,3 +53,40 @@ Device Configuration
 6. Configure the device to run the ``shellhttpd`` app::
    
      fioctl devices config updates <device> --apps shellhttpd
+
+About Targets
+-------------
+
+You can see the available targets your Factory has produced::
+
+  fioctl targets list
+
+**CLI Output**::
+  
+  VERSION  TAGS    APPS        HARDWARE IDs
+  -------  ----    ----        ------------
+  2        devel               raspberrypi3-64
+  3        master              raspberrypi3-64
+  4        master  shellhttpd  raspberrypi3-64
+
+details about target can be printed by passing its version number to the
+``show`` subcommand::
+ 
+  fioctl targets show 4
+
+**CLI Output**::
+
+  Tags:   master
+  CI:     https://ci.foundries.io/projects/stetson/lmp/builds/4/
+  Source:
+          https://source.foundries.io/factories/stetson/lmp-manifest.git/commit/?id=2aaebc4b16c1027c9aae167d6178a8f248027a73
+          https://source.foundries.io/factories/stetson/meta-subscriber-overrides.git/commit/?id=19cbbe7b890eafed4d88e1fb13d2d61ecef8f3e5
+          https://source.foundries.io/factories/stetson/containers.git/commit/?id=6a2ef8d1dbab0db634c52950ae4a7c18494021b2
+  
+  TARGET NAME            OSTREE HASH - SHA256
+  -----------            --------------------
+  raspberrypi3-64-lmp-4  1b0df36794efc32f1c569c8d61f115b04c4d51caa2fa99c17ec85384ae06518d
+  
+  DOCKER APP  VERSION
+  ----------  -------
+  shellhttpd  shellhttpd.dockerapp-4  

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -32,7 +32,7 @@ Default Example
 
 4. :ref:`ref-watch-build`
 
-   When changes are made to containers.git in your Factory sources, a new target is
+   When changes are made to ``containers.git`` in your Factory sources, a new target is
    built by our CI system. Devices that are registered to your Factory will be
    able to see this target and conditionally update to it, depending on their
    device configuration.

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -107,3 +107,7 @@ details about target can be printed by passing its version number to the
    https://docs.foundries.io/latest/customer-factory/configuring.html in
    'configuration', will have to pull this in from master.
 
+.. todo::
+   Give more complex example such as mosquitto, homeassistant, netdata that the
+   user has to recreate rather than just enable with an 'mv' command.
+

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -1,0 +1,38 @@
+Create a Docker-Compose App |:cowboy:|
+======================================
+
+In the :ref:`ref-git-config` section, you should have set up ``git`` with your
+auth token, meaning you can clone your Factory repositories from
+``https://source.foundries.io/factories/<factory>/`` and begin creating new
+targets for your devices to update to.
+
+Default Example
+---------------
+
+1. Clone your containers.git repo and enter it::
+
+     git clone https://source.foundries.io/factories/<factory>/containers.git
+     cd containers.git
+
+  We initialise your ``containers.git`` repository with a simple compose app
+  example in ``shellhttpd.disabled/``
+
+  .. tip:: Directory names ending with ``.disabled`` in containers.git are
+     ignored by our CI system.
+
+2. Enable the ``shellhttpd`` example app::
+ 
+     mv shellhttpd.disabled shellhttpd
+
+3. Add, commit and push::
+
+     git add .
+     git commit -m "shellhttpd: enable shellhttpd app"
+     git push
+
+4. :ref:`ref-watch-build`
+
+   When changes are made to containers.git in your Factory sources, a new target is
+   built by our CI system. Devices that are registered to your Factory will be
+   able to see this target and conditionally update to it, depending on their
+   device configuration.

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -90,3 +90,17 @@ details about target can be printed by passing its version number to the
   DOCKER APP  VERSION
   ----------  -------
   shellhttpd  shellhttpd.dockerapp-4  
+ 
+.. todo::
+   This section links to the flash-target section, yet to be submitted, which
+   details how to install the LmP on a device, it makes the assumption that the
+   device is registered
+
+.. todo::
+   reference unreferenced keywords  
+
+.. todo::
+   add :ref: to
+   https://docs.foundries.io/latest/customer-factory/configuring.html in
+   'configuration', will have to pull this in from master.
+

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -40,7 +40,10 @@ Default Example
 Device Configuration
 --------------------
 
-5. Determine the device you want to configure to use ``shellhttpd``::
+Now that a target is being built, we want to tell our device(s) to update to
+this new target. This is done using :ref:`ref-fioctl`.
+
+1. Determine the device you want to configure to use ``shellhttpd``::
 
      fioctl devices list
 
@@ -50,7 +53,7 @@ Device Configuration
      ----  -------  -----           ------                  ------  ----        ----------
      gavin stetson  <unconfigured>  raspberrypi3-64-lmp-19  OK      simple-app  true
 
-6. Configure the device to run the ``shellhttpd`` app::
+2. Configure the device to run the ``shellhttpd`` app::
    
      fioctl devices config updates <device> --apps shellhttpd
 

--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -36,3 +36,20 @@ Default Example
    built by our CI system. Devices that are registered to your Factory will be
    able to see this target and conditionally update to it, depending on their
    device configuration.
+
+Device Configuration
+--------------------
+
+5. Determine the device you want to configure to use ``shellhttpd``::
+
+     fioctl devices list
+
+   your output should look like this::
+
+     NAME  FACTORY  OWNER           TARGET                  STATUS  APPS        UP TO DATE
+     ----  -------  -----           ------                  ------  ----        ----------
+     gavin stetson  <unconfigured>  raspberrypi3-64-lmp-19  OK      simple-app  true
+
+6. Configure the device to run the ``shellhttpd`` app::
+   
+     fioctl devices config updates <device> --apps shellhttpd

--- a/source/index.rst
+++ b/source/index.rst
@@ -22,6 +22,9 @@ OE/Yocto, the Linux microPlatform™ and Docker®.
    getting-started/signup/index
    getting-started/git-config/index
 
+
+   getting-started/create-compose-app/index
+
 .. ifconfig:: todo_include_todos is True
 
    **Documentation-wide TODO List**


### PR DESCRIPTION
This section details how to enable the shellhttpd default example and configure your device to update to the target produced by the build process.

Additionally, I would like to add an "advanced example" section below that can be revealed by clicking on the title that details a more custom application, such as Mosquitto or Nodered, so that the user can begin tinkering with the factory sources.