### PR TITLE
tagging: Update section for Factory Definition support

### DIFF
--- a/source/customer-factory/managing.rst
+++ b/source/customer-factory/managing.rst
@@ -84,7 +84,7 @@ Once registered, a device's updates options can be remotely managed with
 These updates are handled on the device by the `fioconfig`_ daemon. This
 checks for configuration updates on a configurable periodic interval. The
 factory default is 5 minutes. So - changes can take up to 5 minutes before
-they appear.
+they appear. For more details on tagging see :ref:`ref-advanced-tagging`.
 
 .. _fioctl command line tool:
    https://github.com/foundriesio/fioctl/releases

--- a/source/reference/advanced-tagging.rst
+++ b/source/reference/advanced-tagging.rst
@@ -3,14 +3,14 @@
 Advanced Tagging
 ================
 
-The ``OTA_LITE_TAG`` variable can be used in a few ways to add advanced
-tagging capabilities to a factory.
+Some users incorporate non-trivial workflows that can require advanced tagging
+techniques. These workflows can be handled in the :ref:`ref-factory-defition`
 
 Terminology
 -----------
 
-**Platform Build** - A build created by a change to the LMP/OE. This is the
-base OS image.
+**Platform Build** - A build created by a change to the LmP (lmp-manifest.git
+or meta-subscriber-overrides.git). This is the base OS image.
 
 **Container Build** - A build created by a change to containers.git.
 
@@ -22,32 +22,35 @@ OSTree hash + the output of a Container build.
 tags can be used to say things like "this is a development build"
 or this is a "production" build.
 
-
-OTA_LITE_TAG
-------------
-
-The ``OTA_LITE_TAG`` determines what tag a target will get when a container
-or platform build is performed. The format is::
-
-  TAG[:INHERIT_TAG][,TAG[:INHERIT_TAG]....]
-
-
 Scenario 1: A new platform build that re-uses containers
 --------------------------------------------------------
 
-Consider the case where a factory might have a tag called "postmerge" defined
-for both the lmp.yml and containers.yml builds. A new branch is added to the
-LMP called "postmerge-stable" that's going to be based on older, more stable
-code. However, this new build will use the containers found in the most
-recent "postmerge" target. This can be expressed in lmp.yml with::
+A Factory is set up with the normal ``master`` branch::
 
-  OTA_LITE_TAG: "postmerge-stable:postmerge"
+  lmp:
+    tagging:
+      refs/heads/master:
+        - tag: master
+  containers:
+    tagging:
+      refs/heads/master:
+        - tag: master
 
-However, this means that changes to containers.git will now also need to
-produce a new "postmerge-stable" target. So containers.yaml would need to
-be update with::
+You'd like to introduce a new ``stable`` branch from the LmP but have it use
+the latest containers from master. This can be done with::
 
-  OTA_LITE_TAG: "postmerge,postmerge-stable"
+  lmp:
+    tagging:
+      refs/heads/master:
+        - tag: master
+      refs/heads/stable:
+        - tag: stable
+          inherit: master
+  containers:
+    tagging:
+      refs/heads/master:
+        - tag: master
+        - tag: stable
 
 Consider this pseudo targets example::
 
@@ -55,78 +58,85 @@ Consider this pseudo targets example::
     build-1:
       ostree-hash: DEADBEEF
       docker-apps: foo:v1, bar:v1
-      tags: postmerge-stable
+      tags: stable
     build-2:
       ostree-hash: GOODBEEF
       docker-apps: foo:v2, bar:v2
-      tags: postmerge
+      tags: master
 
-If a change to the postmerge-stable branch was pushed to the LMP, a new
+If a change to the stable branch was pushed to the LmP, a new
 target, build-3, would be added. The build logic would then look through
-the targets list to find the most recent "postmerge" target so that
+the targets list to find the most recent ``master`` target so that
 it can copy those docker-apps. This would result in a new target::
 
   build-3:
     ostree-hash: NEWHASH
     docker-apps: foo:v2, bar:v2
-    tags: postmerge-stable
+    tags: stable
 
+On the other hand, there might also be a new container build for ``master``.
+In this case the build logic will produce two new targets::
 
-On the other hand, there might also be a new container build for "postmerge".
-In this case the tag specification ``postmerge,postmerge-stable`` would tell
-the build logic to produce two new targets::
-
-  build-4:  # for postmerge-stable it will be based on build-3
+  build-4:  # for stable it will be based on build-3
     ostree-hash: NEWHASH
     docker-apps: foo:v3, bar:v3
-    tags: postmerge-stable
+    tags: stable
 
-  build-4:  # for postmerge, it will be based on build-2
+  build-4:  # for master, it will be based on build-2
     ostree-hash: GOODBEEF
     docker-apps: foo:v3, bar:v3
-    tags: postmerge
-
+    tags: master
 
 Scenario 2: Multiple container builds using the same platform
 -------------------------------------------------------------
 
 This scenario is the reverse of the previous one. A factory might have a
-platform build tagged with "devel-X". However, there are two versions of
-containers being worked on: "devel-X" and "devel-Y". This could be handled
-by changing lmp.yml to::
+platform build tagged with ``master``. However, there are two versions of
+containers being worked on: ``master`` and ``foo``. This could be handled
+with::
 
- OTA_LITE_TAG: "devel-X,devel-Y"
-
-
-and containers.yml to::
-
- OTA_LITE_TAG: "devel-X,devel-Y:devel-X"
+  lmp:
+    tagging:
+      refs/heads/master:
+        - tag: master
+        - tag: foo
+  containers:
+    tagging:
+      refs/heads/master:
+        - tag: master
+      refs/heads/foo:
+        - tag: foo
+          inherit: master
 
 Scenario 3: Multiple teams, different cadences
 ----------------------------------------------
 
 Some organizations may have separate core platform and application teams. In
 this scenario, it may be desirable to let each team move at their own decoupled
-paces. Furthermore, the applications team might have stages(branches) of
-development they are working on. This could be handled by changing lmp.yml to::
+paces. Furthermore, the application team might have stages(branches) of
+development they are working on. This could be handled with something like::
 
- OTA_LITE_TAG: "devel-core"
+  lmp:
+    tagging:
+      refs/heads/master:
+        - tag: master
+  containers:
+    tagging:
+      refs/heads/master:
+        - tag: master
+      refs/heads/dev:
+        - tag: dev
+          inherit: master
+      refs/heads/qa:
+        - tag: qa
+          inherit: master
 
-Then each branch of development for the containers could have things like::
+This scenario is going to produce ``master`` tagged builds that have no
+containers, but can be generically verified. Then each containers.git branch
+will build Targets and grab the latest ``master`` tag to base its platform
+on. **NOTE:** Changes to ``master`` don't cause new container builds. In
+order to get a container's branch updated to the latest ``master`` a user
+would need to push an empty commit to containers.git to trigger a new build::
 
- # For the "app-dev" branch of containers.git
- OTA_LITE_TAG: "app-dev:devel-core"
-
- # For the "app-qa" branch of containers.git
- OTA_LITE_TAG: "app-qa:devel-core"
-
-This scenario is going to produce ``devel`` tagged builds that have no
-containers, but can be generically verfied. Then each containers.git branch
-will build targets and grab the latest "devel-core" tag to base its platform
-on. **NOTE:** Changes to devel-core don't cause new container builds. In
-order to get a container's branch updated to the latest ``devel-core`` a user
-would need to push an empty commit to containers.git to trigger a new build.
-eg::
-
- # from branch app-dev
- git commit --allow-empty -m 'Pull in latest devel-core changes'
+ # from branch qa
+ git commit --allow-empty -m 'Pull in latest platform changes from master'

--- a/source/reference/factory-definition.rst
+++ b/source/reference/factory-definition.rst
@@ -1,7 +1,7 @@
 .. _ref-factory-defition:
 
-The Factory Definition
-======================
+Factory Definition
+==================
 
 Each Factory can be customized to control how CI handles it. This is managed
 in the "Factory Definition" which is located in a factory's ci-scripts.git


### PR DESCRIPTION
This section of the docs predates our factory definition support and was
incorrect. This rewords things to match how it can be done now.

Signed-off-by: Andy Doan <andy@foundries.io>