### PR TITLE
fix: Fix project name

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -144,7 +144,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'FoundriesFactory<sup>&#174;</sup>'
+project = 'FoundriesFactory'
 copyright = '2017-2020, Foundries.io, Ltd'
 author = 'Foundries.io, Ltd.'
 


### PR DESCRIPTION
  * Remove HTML tags from project name as they are not
    correctly rendered in the page title and breaks
    Google Search API, returning bad characters.

Signed-off-by: Milo Casagrande <milo@foundries.io>