### PR TITLE
reference-manual: set menu depth to 2

### DIFF
--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -177,7 +177,7 @@ Completion
 
 Now that you're done, you might want to read :ref:`sec-tutorials` to see some
 examples of the things that can be done with your Factory. Additionally, you can
-read the :ref:`ref-manual` to learn more about the architecture of
+read the :ref:`sec-manual` to learn more about the architecture of
 FoundriesFactory and the Linux microPlatform.
 
 .. todo::

--- a/source/reference-manual/index.rst
+++ b/source/reference-manual/index.rst
@@ -1,8 +1,5 @@
 .. _ref-manual:
 
-Reference Manual
-================
-
 .. toctree::
    :maxdepth: 2
    :glob:


### PR DESCRIPTION
Having a title and a top level link to the reference manual isn't very helpful. Expose the reference subsection titles are the top level for the user.

Signed-off-by: Tyler Baker <tyler@foundries.io>