### PR TITLE
getting-started: fix index order, dependency on flash-device

### DIFF
--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -94,6 +94,14 @@ details about target can be printed by passing its version number to the
   ----------  -------
   shellhttpd  shellhttpd.dockerapp-4
 
+Completion
+----------
+
+Now that you're done, you might want to read :ref:`sec-tutorials` to see some
+examples of the things that can be done with your Factory. Additionally, you can
+read the :ref:`ref-manual` to learn more about the architecture of
+FoundriesFactory and the Linux microPlatform.
+
 .. todo::
    This section links to the flash-target section, yet to be submitted, which
    details how to install the LmP on a device, it makes the assumption that the

--- a/source/getting-started/register-device/index.rst
+++ b/source/getting-started/register-device/index.rst
@@ -36,11 +36,3 @@ register your device(s) via the Foundries.io REST API.
    Or by using :ref:`ref-fioctl`::
 
      fioctl devices list
-
-Completion
-----------
-
-Now that you're done, you might want to read :ref:`sec-tutorials` to see some
-examples of the things that can be done with your Factory. Additionally, you can
-read the :ref:`ref-manual` to learn more about the architecture of
-FoundriesFactory and the Linux microPlatform.

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,9 +14,9 @@ OE/Yocto, the Linux microPlatform™ and Docker®.
    getting-started/signup/index
    getting-started/git-config/index
    getting-started/install-fioctl/index
-   getting-started/create-compose-app/index
    getting-started/flash-device/index
    getting-started/register-device/index
+   getting-started/create-compose-app/index
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Signed-off-by: Matthew Croughan <matthew.croughan@foundries.io>

Initially, when creating getting-started, I noticed that this step of creating the compose app wouldn't necessarily be dependent upon flashing the device. However, I ended up explaining some steps that *are* dependent on flashing the device, such as `fioctl devices list`. Ideally, the user would be completing this step whilst their first build is being produced, since this takes time. So I will simply move this section lower in the index for now until I rewrite this section for the beta app release with better thought given to making it independent from flash-device.