### PR TITLE
linux: improve building from scratch instructions

### DIFF
--- a/source/reference-manual/linux/linux-building.rst
+++ b/source/reference-manual/linux/linux-building.rst
@@ -74,7 +74,8 @@ at known-good revisions, and keep them in sync as time goes on.
 
      mkdir lmp && cd lmp
 
-   (You can also reuse an existing installation directory.)
+   (You can also reuse an existing installation directory, or ``/build/lmp``
+   if building inside the lmp-sdk container, as described at :ref:`ref-linux-dev-container`)
 
 #. Install update |version| using repo:
 
@@ -93,7 +94,7 @@ The supported ``MACHINE`` target used by this guide is
 :ref:`ref-linux-supported`.)
 
 The default distribution (``DISTRO``) is automatically set to ``lmp``,
-which is provided by the meta-lmp layer (see
+which is provided by the meta-lmp-base layer (see
 :ref:`ref-linux-layers` for more details).
 
 Set up your work environment using the ``setup-environment`` script::

--- a/source/reference-manual/linux/linux-dev-container.rst
+++ b/source/reference-manual/linux/linux-dev-container.rst
@@ -5,26 +5,34 @@
 Development Container
 =====================
 
-You can install a Docker container based on Ubuntu 18.04 which
-provides a Linux microPlatform build environment. This is the
-recommended work environment for building Linux microPlatform images
-on macOS and Windows.
+You can install a Docker container based on Ubuntu 20.04 which
+provides a Linux microPlatform build environment (this is the same
+container image as used by our own CI). This is the recommended work
+environment for building Linux microPlatform images on macOS and Windows.
 
 #. `Install Docker`_.
+
+#. Create local folders for ``sstate-cache``, ``downloads`` and ``build``,
+   as a way to save the build environment outside the container:
+
+   .. parsed-literal::
+
+      mkdir -p ~/lmp/sstate-cache ~/lmp/downloads ~/lmp/build
 
 #. Run update |version| of the container as the ``builder`` user:
 
    .. parsed-literal::
 
-      docker run -it -u builder --name lmp-sdk hub.foundries.io/lmp-sdk:|docker_tag|
+      docker run --rm -u builder --name lmp-sdk -v ~/lmp/build:/build/lmp -v ~/lmp/sstate-cache:/build/lmp/sstate-cache -v ~/lmp/downloads:/build/lmp/downloads -it hub.foundries.io/lmp-sdk:|docker_tag|
 
-#. Set up Git inside the container::
+#. Set up Git inside the container (required by ``repo``)::
 
       git config --global user.name "Your Full Name"
       git config --global user.email "your-email-address@example.com"
 
-You can now follow instructions in :ref:`ref-linux-building` to
-build the Linux microPlatform inside the running container.
+You can now follow instructions in :ref:`ref-linux-building-install` to
+build the Linux microPlatform inside the running container, using
+``/build/lmp`` as your main work folder.
 
 .. _Install Docker:
    https://docs.docker.com/install/


### PR DESCRIPTION
Show how to use a shared folder when running the docker container, and
improve the standard build instructions to make it more clear.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>