### PR TITLE
getting-started: update flags on fioctl targets

### DIFF
--- a/source/getting-started/create-compose-app/index.rst
+++ b/source/getting-started/create-compose-app/index.rst
@@ -56,7 +56,11 @@ Example Apps
       that has been defined will be available for usage in this Target. This can
       be verified by running::
 
-        fioctl targets list
+        fioctl targets list --factory gavin
+
+      .. note::
+
+         'gavin' is the name used in :ref:`gs-signup`.
 
       **By default** devices will run **all** applications that are defined in
       the :term:`containers.git` repository and therefore available in the
@@ -120,7 +124,11 @@ Example Apps
       that has been defined will be available for usage in this Target. This can
       be verified by running::
 
-        fioctl targets list
+        fioctl targets list --factory gavin
+
+      .. note::
+
+         'gavin' is the name used in :ref:`gs-signup`.
 
       **By default** devices will run **all** applications that are defined in
       the :term:`containers.git` repository and therefore available in the
@@ -134,7 +142,7 @@ About Targets
 
 You can see the available Targets your Factory has produced::
 
-  fioctl targets list
+  fioctl targets list --factory gavin
 
 **CLI Output**::
 
@@ -147,7 +155,7 @@ You can see the available Targets your Factory has produced::
 details about Target can be printed by passing its version number to the
 ``show`` subcommand::
 
-  fioctl targets show 4
+  fioctl targets show 4 --factory gavin
 
 **CLI Output**::
 

--- a/source/glossary/index.rst
+++ b/source/glossary/index.rst
@@ -10,7 +10,7 @@ Terminology
      Hash and Docker-Compose App URIs, but is arbitrary.
   
    targets.json
-     The output of ``fioctl targets list -r``
+     The output of ``fioctl targets list -r --factory <factory>``
   
    Docker-Compose App
      Also referred to as 'app'. A folder in :term:`containers.git`, containing a

--- a/source/reference-manual/docker/compose-apps.rst
+++ b/source/reference-manual/docker/compose-apps.rst
@@ -43,7 +43,7 @@ is distributed as compose apps. Here is a simplistic source layout::
 When changes are made to containers.git, the factory will produce a new
 Target that includes the updated ``httpd`` compose app::
 
-  $ fioctl targets show 77
+  $ fioctl targets show 77 --factory <factory>
 
   ... <snip>
 

--- a/source/reference-manual/ota/device-tags.rst
+++ b/source/reference-manual/ota/device-tags.rst
@@ -73,7 +73,7 @@ By default LMP builds triggered in your factory after code has been merged to
 master will be tagged with "postmerge". After doing QA on this build, it can
 be "promoted" using the fioctl_ tool::
 
- fioctl targets tag -Tpostmerge,promoted raspberrypi3-64-lmp-144
+ fioctl targets tag -Tpostmerge,promoted raspberrypi3-64-lmp-144 --factory <factory>
 
 That will kick off a CI job that will tag build 144 as promoted. This would
 result in the Device 2 from the example above in updating.

--- a/source/reference-manual/troubleshooting/troubleshooting.rst
+++ b/source/reference-manual/troubleshooting/troubleshooting.rst
@@ -50,8 +50,8 @@ your Factory, allowing the production of new Targets.
 
 You can individually prune/delete targets by their Target number::
 
-  fioctl targets prune <target_number>
+  fioctl targets prune <target_number> --factory <factory>
 
 Or, you can prune by tag, such as ``devel`` or ``experimental``::
 
-  fioctl targets prune --by-tag <tag>
+  fioctl targets prune --by-tag <tag> --factory <factory>

--- a/source/user-guide/fioctl/index.rst
+++ b/source/user-guide/fioctl/index.rst
@@ -68,14 +68,14 @@ Target metadata can be inspected by using 3 primary commands
 
          .. code-block:: 
          
-           $ fioctl targets list
+           $ fioctl targets list --factory <factory>
            VERSION  TAGS    APPS                             HARDWARE IDs
            -------  ----    ----                             ------------
            1        master  simple-app,netdata               raspberrypi3-64
            2        devel   mosquitto,simple-app,netdata     raspberrypi3-64
            3        devel   simple-app,netdata,mosquitto     raspberrypi3-64
 
-``fioctl targets list -r`` 
+``fioctl targets list -r --factory <factory>``
     Lists the Targets a Factory has produced in ``-r`` (raw) json format.
     This is often piped into ``jq`` in order to format the json neatly.
 
@@ -92,7 +92,7 @@ Target metadata can be inspected by using 3 primary commands
             :linenos:
             :emphasize-lines: 16,37-45
          
-              $ fioctl targets list -r | jq
+              $ fioctl targets list -r --factory <factory> | jq
               {
                 "signatures": [
                   {
@@ -143,8 +143,8 @@ Target metadata can be inspected by using 3 primary commands
                       }
                     }
 
-``fioctl targets show <target>``
-    Prints detail about a specific Target, (e.g ``fioctl targets show 58``).
+``fioctl targets show <target> --factory <factory>``
+    Prints detail about a specific Target, (e.g ``fioctl targets show 58 --factory <factory>``).
 
     These details include:
     
@@ -161,7 +161,7 @@ Target metadata can be inspected by using 3 primary commands
 
          .. code-block::
          
-           $ fioctl targets show 58
+           $ fioctl targets show 58 --factory <factory>
            Tags:	devel
            CI:	https://ci.foundries.io/projects/cowboy/lmp/builds/58/
            Source:


### PR DESCRIPTION
--factory flag is now mandatory when using 'fioctl targets'.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>