### PR TITLE
getting-started::register-device: warn that all apps will be enabled by default

### DIFF
--- a/source/getting-started/register-device/index.rst
+++ b/source/getting-started/register-device/index.rst
@@ -11,6 +11,13 @@ register your device(s) via the Foundries.io REST API.
 
      sudo lmp-device-register -n <device-name>
 
+   .. note:: 
+
+	**By default** devices will run **all** applications that are defined in
+	the :term:`containers.git` repository and therefore available in the
+	latest Target. This behavior can be changed by enabling only specific
+	applications. Read :ref:`ug-fioctl-enable-apps` to learn how.
+
 2. You will be prompted by ``lmp-device-register`` to complete a challenge with
    our API
 


### PR DESCRIPTION
This warns that all apps will be enabled by default in the lmp-device-register section.

This is also referenced in the create-compose-app section

Signed-off-by: Matthew Croughan <matthew.croughan@foundries.io>