### PR TITLE
imx6ullevk-sec: Instructions for enabling secure book on a imx6ullevk baord

### DIFF
--- a/source/_static/csv/supported-boards.csv
+++ b/source/_static/csv/supported-boards.csv
@@ -6,6 +6,7 @@ Arm Neoverse N1 System Development Platform (N1SDP),n1sdp
 Intel NUC8,intel-corei7-64
 Intel x86-64 UEFI,intel-corei7-64
 NXP iMX6ULL-EVK,imx6ullevk
+NXP iMX6ULL-EVK with secure boot enabled,imx6ullevk-sec
 EA iMX7ULP-UCOM,imx7ulpea-ucom
 NXP iMX8M-MINILPD4 EVK,imx8mmevk
 NXP iMX8MQuad EVK,imx8mqevk

--- a/source/reference-manual/boards/imx6-prepare.rst
+++ b/source/reference-manual/boards/imx6-prepare.rst
@@ -4,7 +4,7 @@ Preparation
 Ensure you replace the ``<factory>`` placeholder below with the name of your
 Factory.
 
-Download necessary files from ``https://app.foundries.io/factories/<factory/targets``
+Download necessary files from ``https://app.foundries.io/factories/<factory>/targets``
 
 #. Click the latest Target with the :guilabel:`platform-devel` trigger.
 

--- a/source/reference-manual/boards/imx6-prepare.rst
+++ b/source/reference-manual/boards/imx6-prepare.rst
@@ -17,7 +17,7 @@ Download necessary files from ``https://app.foundries.io/factories/<factory>/tar
    machine.**
 
    | E.g: ``lmp-factory-image-imx6ullevk.wic.gz``
-   |      ``SPL-imx6ullevkevk``
+   |      ``SPL-imx6ullevk``
    |      ``u-boot-imx6ullevk.itb``
 
    .. figure:: /_static/boards/imx6-steps-2.png

--- a/source/reference-manual/boards/imx6ull.rst
+++ b/source/reference-manual/boards/imx6ull.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_imx6ullevk:
+
 i.MX 6ULL Evaluation Kit
 ========================
 

--- a/source/reference-manual/security/imx-generic-custom-keys.rst
+++ b/source/reference-manual/security/imx-generic-custom-keys.rst
@@ -1,0 +1,106 @@
+
+How to use custom keys
+----------------------
+
+Create the keys
+^^^^^^^^^^^^^^^
+
+There are different ways to create and store the needed keys for the secure
+boot. One important reference to understand how to generate the PKI tree is
+`i.MX Secure Boot on HABv4 Supported Devices`_ application note from NXP.
+
+In addition, the U-Boot project also includes a documentation on `Generating a
+fast authentication PKI tree`_.
+
+.. warning:: It is critical that the keys created in this process must be stored
+  in a secure and safe place. When the keys are fused to the board, that board
+  will only boot signed images. So the keys are required in future steps.
+
+Generate the MfgTools scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is a set of scripts to help with creating the set of commands used to fuse
+the key into the fuse banks of ``<machine>``, and to close the board which
+configures the board to only boot signed images.
+
+1. Clone the ``lmp-tools`` from GitHub
+
+.. prompt:: bash host:~$
+
+      git clone git://github.com/foundriesio/lmp-tools.git
+
+2. Export the path to where keys are stored
+
+.. prompt:: bash host:~$
+
+    export KEY_PATH=/path-to-key-files
+
+3. Generate the script to fuse the board
+
+.. prompt:: bash host:~$
+
+      cd lmp-tools/
+      cd security/imx6ull
+      ./gen_fuse.sh -s $KEY_PATH
+
+4. Generate the script to close the board
+
+.. prompt:: bash host:~$
+
+      cd lmp-tools/
+      cd security/imx6ull
+      ./gen_close.sh -s $KEY_PATH
+
+5. Install the scripts to the ``meta-subscriber-overrides``:
+
+.. prompt:: bash host:~$
+
+      mkdir -p <factory>/meta-subscriber-overrides/recipes-support/mfgtool-files/mfgtool-files/<machine>
+      cp fuse.uuu <factory>/meta-subscriber-overrides/recipes-support/mfgtool-files/mfgtool-files/<machine>
+      cp close.uuu <factory>/meta-subscriber-overrides/recipes-support/mfgtool-files/mfgtool-files/<machine>
+      cat <factory>/meta-subscriber-overrides/recipes-support/mfgtool-files/mfgtool-files_%.bbappend
+
+The content of ``mfgtool-files_%.bbappend`` should be::
+
+    FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+    SRC_URI_append_<machine> = " \
+        file://fuse.uuu \
+        file://close.uuu \
+    "
+
+    do_deploy_prepend_<machine>() {
+        install -d ${DEPLOYDIR}/${PN}
+        install -m 0644 ${WORKDIR}/fuse.uuu ${DEPLOYDIR}/${PN}/fuse.uuu
+        install -m 0644 ${WORKDIR}/close.uuu ${DEPLOYDIR}/${PN}/close.uuu
+    }
+
+.. tip:: Replace the machine name in case the factory is using a custom machine name.
+
+6. Inspect the changes and push it accordingly
+
+.. prompt:: bash host:~$
+
+      git status
+
+The result of ``git status`` should look like::
+
+      On branch devel
+      Your branch is up to date with 'origin/devel'.
+
+      Changes to be committed:
+      (use "git restore --staged <file>..." to unstage)
+          new file:   recipes-support/mfgtool-files/mfgtool-files/<machine>/close.uuu
+          new file:   recipes-support/mfgtool-files/mfgtool-files/<machine>/fuse.uuu
+          new file:   recipes-support/mfgtool-files/mfgtool-files_%.bbappend
+
+The changes add the UUU scripts to the ``mfgtool-files`` artifacts of next
+targets. Run the ``fuse.uuu`` and ``close.uuu`` to fuse the custom keys and
+close the board, respectively.
+
+.. warning:: The scripts ``fuse.uuu`` and ``close.uuu`` include commands which
+  result is irreversible. The  scripts should be executed with caution and only
+  after understanding its critical implications.
+
+.. _i.MX Secure Boot on HABv4 Supported Devices: https://www.nxp.com/webapp/Download?colCode=AN4581&location=null
+.. _Generating a fast authentication PKI tree: https://source.codeaurora.org/external/imx/uboot-imx/tree/doc/imx/habv4/introduction_habv4.txt?h=imx_v2020.04_5.4.70_2.3.0#n191

--- a/source/reference-manual/security/secure-boot-imx6ullevk-sec.rst
+++ b/source/reference-manual/security/secure-boot-imx6ullevk-sec.rst
@@ -1,0 +1,84 @@
+.. highlight:: sh
+
+.. _ref-secure-boot-imx6ullevk-sec:
+
+NXP iMX6ULL-EVK with secure boot enabled by FoundriesFactory
+============================================================
+
+The machine ``imx6ullevk-sec`` is the ``imx6ullevk`` machine configured to have
+segure boot enabled by default.
+
+The purpose of this machine is to gather the needed configuration to enable
+secure boot and provide a set of artifacts to help in the process needed to have
+the hardware board set to secure boot.
+
+.. warning::
+
+    It is recommended to read :ref:`ref-secure-boot-imx` before proceeding with
+    the following steps.
+
+How to enable
+-------------
+
+In the ``ci-scripts`` git repository from the FoundriesFactory, update the
+``factory-config.yml`` to include the following configuration::
+
+    machines:
+    - imx6ullevk-sec
+
+    mfg_tools:
+    - machine: imx6ullevk-sec
+        params:
+        DISTRO: lmp-mfgtool
+        IMAGE: mfgtool-files
+        EXTRA_ARTIFACTS: mfgtool-files.tar.gz
+        UBOOT_SIGN_ENABLE: "1"
+
+How to use
+----------
+
+Trigger a platform build and wait until the target is created.
+
+Follow the steps from :ref:`ref-rm_board_imx6ullevk` to prepare the hardware and
+download the same artifacts.
+
+The list of artifacts downloaded should be:
+
+* ``mfgtool-files-imx6ullevk-sec.tar.gz``
+* ``lmp-factory-image-imx6ullevk-sec.wic.gz``
+* ``SPL-imx6ullevk-sec``
+* ``u-boot-imx6ullevk-sec.itb``
+
+Expand the tarballs:
+
+.. prompt:: bash host:~$
+
+    gunzip lmp-factory-image-imx6ullevk.wic.gz
+    tar -zxvf mfgtool-files-imx6ullevk.tar.gz
+
+The resultant directory tree should look like the following::
+
+    ├── lmp-factory-image-imx6ullevk-sec.wic
+    ├── mfgtool-files-imx6ullevk-sec
+    │   ├── bootloader.uuu
+    │   ├── close.uuu
+    │   ├── full_image.uuu
+    │   ├── fuse.uuu
+    │   ├── readme.md
+    │   ├── SPL-mfgtool
+    │   ├── u-boot-mfgtool.itb
+    │   ├── uuu
+    │   └── uuu.exe
+    ├── mfgtool-files-imx6ullevk-sec.tar.gz
+    ├── SPL-imx6ullevk-sec
+    └── u-boot-imx6ullevk-sec.itb
+
+
+Follow ``readme.md`` instructions to sign the SPL images, to fuse, and close the
+board.
+
+.. warning:: The **fuse** and **close** procedures are irreversible. The
+  instructions from the ``readme.md`` file should be followed and executed with
+  caution and only after understanding the critical implication of those commands.
+
+.. include:: imx-generic-custom-keys.rst

--- a/source/reference-manual/security/secure-boot.rst
+++ b/source/reference-manual/security/secure-boot.rst
@@ -9,3 +9,4 @@ Secure Boot
    :maxdepth: 1
 
    secure-boot-imx
+   secure-boot-imx6ullevk-sec


### PR DESCRIPTION
It does not include the instructions from [readme.md](https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk-sec/readme.md) file, but points the reader to follow them from the file.

It also adds the instructions to create and replace the UUU scripts.

It does **not** include instructions on how to create keys.