### PR TITLE
user-guide:configure-lmp: How to enable PRODUCTION=on on LmP

### DIFF
--- a/source/reference-manual/security/factory-registration-ref.rst
+++ b/source/reference-manual/security/factory-registration-ref.rst
@@ -33,6 +33,32 @@ it does have a couple of potential drawbacks:
  * Devices won't have Foundries.io managed configuration data available
    until this first connection.
 
+Registering Production Device by Default
+----------------------------------------
+
+After the development cycle is over, and it is expected that every new
+device to be registered is a production device, it might be good to enable this
+by default in LmP.
+
+Create or modify the bbappend file in the factory's ``meta-subscriber-overrides``:
+
+.. prompt:: bash host:~$
+
+   mkdir -p meta-subscriber-overrides/recipes-sota/lmp-device-register/
+   gedit lmp-device-register_%.bbappend
+
+Add the following line to the ``lmp-device-register_%.bbappend`` file:
+
+.. prompt:: text
+
+   PACKAGECONFIG += "production"
+
+The images created with this configuration includes ``PRODUCTION=on`` by default
+on the command ``lmp-device-register``.
+
+This is very usefully when the update plan is to use
+:ref:`ref-production-targets`.
+
 lmp-device-auto-register configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 lmp-device-register must be called with two environment variables

--- a/source/reference-manual/security/factory-registration-ref.rst
+++ b/source/reference-manual/security/factory-registration-ref.rst
@@ -40,18 +40,13 @@ After the development cycle is over, and it is expected that every new
 device to be registered is a production device, it might be good to enable this
 by default in LmP.
 
-Create or modify the bbappend file in the factory's ``meta-subscriber-overrides``:
+Create or modify the ``lmp-device-register_%.bbappend`` file in the factory's
+``meta-subscriber-overrides``:
 
 .. prompt:: bash host:~$
 
    mkdir -p meta-subscriber-overrides/recipes-sota/lmp-device-register/
-   gedit lmp-device-register_%.bbappend
-
-Add the following line to the ``lmp-device-register_%.bbappend`` file:
-
-.. prompt:: text
-
-   PACKAGECONFIG += "production"
+   echo "PACKAGECONFIG += \"production\"" >> meta-subscriber-overrides/recipes-sota/lmp-device-register/lmp-device-register_%.bbappend
 
 The images created with this configuration includes ``PRODUCTION=on`` by default
 on the command ``lmp-device-register``.

--- a/source/user-guide/configure-lmp/index.rst
+++ b/source/user-guide/configure-lmp/index.rst
@@ -277,28 +277,3 @@ There are no variables for this recipe.
 
 .. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master
 .. _meta-lmp-base: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base
-
-Registering Production Device by Default
-----------------------------------------
-
-After the development cycle is over, and it is expected that every new
-device to be registered is a production device, it might be good to enable this
-by default in LmP.
-
-Create or modify the bbappend file in the factory's ``meta-subscriber-overrides``:
-
-.. prompt:: bash host:~$
-
-   mkdir -p meta-subscriber-overrides/recipes-sota/lmp-device-register/
-   gedit lmp-device-register_%.bbappend
-
-Add the following line to the ``lmp-device-register_%.bbappend`` file:
-
-.. prompt:: text
-
-   PACKAGECONFIG += "production"
-
-The images created with this configuration includes ``PRODUCTION=on`` by default
-on the command ``lmp-device-register``.
-
-This is very usefully when the update plan is to use :ref:`ref-production-targets`.

--- a/source/user-guide/configure-lmp/index.rst
+++ b/source/user-guide/configure-lmp/index.rst
@@ -277,3 +277,28 @@ There are no variables for this recipe.
 
 .. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master
 .. _meta-lmp-base: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base
+
+Registering Production Device by Default
+----------------------------------------
+
+After the development cycle is over, and it is expected that every new
+device to be registered is a production device, it might be good to enable this
+by default in LmP.
+
+Create or modify the bbappend file in the factory's ``meta-subscriber-overrides``:
+
+.. prompt:: bash host:~$
+
+   mkdir -p meta-subscriber-overrides/recipes-sota/lmp-device-register/
+   gedit lmp-device-register_%.bbappend
+
+Add the following line to the ``lmp-device-register_%.bbappend`` file:
+
+.. prompt:: text
+
+   PACKAGECONFIG += "production"
+
+The images created with this configuration includes ``PRODUCTION=on`` by default
+on the command ``lmp-device-register``.
+
+This is very usefully when the update plan is to use :ref:`ref-production-targets`.


### PR DESCRIPTION
How to enable production devices registration by default on LmP creating
a bbappend to change PACKAGEGROUP default.

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>