### PR TITLE
sphinx-toolbox: updating version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ sphinx-tabs==1.3.0
 sphinxemoji==0.1.6
 sphinx_copybutton==0.3.0
 sphinxcontrib.asciinema==0.2.0
-sphinx_toolbox==1.7.5
+sphinx_toolbox==2.11.2
 sphinx-prompt==1.4.0


### PR DESCRIPTION
After starting get the error:
Could not import extension sphinx_toolbox.confval (exception: No module named 'cachecontrol')

Couldn't find why it is happening but figure out that the new version fixed that.