### PR TITLE
reference-manual: linux: Add early start recipe to preloaded images

### DIFF
--- a/source/reference-manual/linux/preloaded-images.rst
+++ b/source/reference-manual/linux/preloaded-images.rst
@@ -42,10 +42,10 @@ a Factory may have their containers.git set up like::
   # experimental and devel branches:
   fiotest          - A compose-app that some devices run for QA.
   money-making-app - The "product"
-  debug-tools      - A compose-app with some tooling used for devel
+  debug-tools      - A compose app with some tooling used for devel
 
   # master branch
-  fiotest          - A compose-app that some devices run for QA.
+  fiotest          - A compose app that some devices run for QA.
   money-making-app - The "product"
 
   # production branch
@@ -137,3 +137,65 @@ Preloading could be set by doing a union of these two sets of apps,
 container's master branch and the "devel" Target will have both
 money-making-app and debug-tools preloaded from the container's
 devel branch.
+
+Starting compose apps early
+---------------------------
+Preloading docker images doesn't mean the compose apps start automatically.
+Usually compose apps are started by aktualizr-lite after device registration.
+However, aktualizr-lite first checks for available updates. If there is a new
+target available compose apps will only be started after the update is performed.
+
+.. note::
+
+   Note that this mainly applies to the first launch of compose apps. If
+   ``docker-compose.yml`` contains **restart** clause, the container will be started
+   by dockerd on subsequent boots.
+
+In some scenarios it is required that compose apps start before device
+registration and before aktualizr-lite on a freshly flashed device. This can
+be done using one off systemd service and image with pre-loaded containers.
+
+Example compose apps early start script can be found in meta-lmp:
+
+  https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-support/compose-apps-early-start
+
+The recipe produces a systemd one off service and shell script.
+
+.. note::
+
+   The systemd startup service only runs when the device is **not** registered
+   to the Foundries Factory. Otherwise the script is not executed.
+
+The following patch for meta-subscriber-overrides is required to add the
+recipe to the lmp-factory-image
+
+    .. code-block::
+
+        --- a/recipes-samples/images/lmp-factory-image.bb
+        +++ b/recipes-samples/images/lmp-factory-image.bb
+        @@ -24,9 +24,10 @@ CORE_IMAGE_BASE_INSTALL += " \
+             networkmanager-nmcli \
+             git \
+             vim \
+        +    compose-apps-early-start \
+             packagegroup-core-full-cmdline-utils \
+             packagegroup-core-full-cmdline-extended \
+             packagegroup-core-full-cmdline-multiuser \
+
+
+The shell script checks for the list of compose apps to start in the
+``/var/lmp/default-apps`` file. This file can't be provided by OSTree so it needs
+to be created at runtime. If the file is not present all available compose
+apps are started.
+
+Compose apps listed in the default-apps file should be started as soon
+as the docker service is started. In addition to that, when **restart** clause
+is present in the compose app service, it will be started by dockerd on every
+boot if it was at least once started by the script. Example:
+
+.. code-block::
+
+   services:
+       fiotest:
+           image: hub.foundries.io/demo/fiotest
+           restart: always


### PR DESCRIPTION
This patch adds a section in the preload-images describing how to start
compose apps early in the boot sequence, not waiting for the
aktualizr-lite.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>