### PR TITLE
reference-manual: add cross reference to board pages

### DIFF
--- a/source/_static/csv/supported-boards.csv
+++ b/source/_static/csv/supported-boards.csv
@@ -3,23 +3,24 @@ Arm Corstone-700 MPS3,corstone700-mps3
 Arm Corstone-700 FVP,corstone700-fvp
 Arm Cortex A5 DesignStart,a5ds
 Arm Neoverse N1 System Development Platform (N1SDP),n1sdp
-Intel NUC8,intel-corei7-64
-Intel x86-64 UEFI,intel-corei7-64
-NXP iMX6ULL-EVK,imx6ullevk
-NXP iMX6ULL-EVK with secure boot enabled,imx6ullevk-sec
+:ref:`Intel NUC8 <ref-rm_board_intel-corei7-64>`,intel-corei7-64
+:ref:`Intel x86-64 UEFI <ref-rm_board_intel-corei7-64>`,intel-corei7-64
+:ref:`NXP iMX6ULL-EVK <ref-rm_board_imx6ullevk>`,imx6ullevk
+:ref:`NXP iMX6ULL-EVK with secure boot enabled <ref-secure-boot-imx6ullevk-sec>`,imx6ullevk-sec
 EA iMX7ULP-UCOM,imx7ulpea-ucom
-NXP iMX8M-MINILPD4 EVK,imx8mmevk
-NXP iMX8MQuad EVK,imx8mqevk
+:ref:`NXP iMX8M-MINILPD4 EVK <ref-rm_board_imx8mmevk>`,imx8mmevk
+:ref:`NXP iMX8MQuad EVK <ref-rm_board_imx8mqevk>`,imx8mqevk
 NXP Solidrun CuBox-i iMX6,cubox-i
-NXP Toradex Apalis-iMX6,apalis-imx6
+:ref:`NXP Toradex Apalis-iMX6 <ref-rm_boards_imx6ullevk-sec>`,apalis-imx6
 NXP Toradex Apalis-iMX8QM,apalis-imx8
 NXP Toradex Colibri-iMX7 (Aster),colibri-imx7-emmc
-QEMU AARCH64,qemuarm64
-QEMU RISCV-64,qemuriscv64
-Raspberry Pi3 (32 bit and CM),raspberrypi3
-Raspberry Pi3/3B (64 bit),raspberrypi3-64
-Raspberry Pi4,raspberrypi4-64
+:ref:`QEMU AARCH64 <ref-rm_qemu_arm64>`,qemuarm64
+:ref:`QEMU RISCV-64 <ref-rm_qemu_riscv64>`,qemuriscv64
+:ref:`Raspberry Pi3 (32 bit and CM) <ref-rm_board_rasbperrypi>`,raspberrypi3
+:ref:`Raspberry Pi3/3B (64 bit) <ref-rm_board_rasbperrypi>`,raspberrypi3-64
+:ref:`Raspberry Pi4 <ref-rm_board_rasbperrypi>`,raspberrypi4-64
 SiFive HiFive Unleashed,freedom-u540
-TI AM64x SKEVM,am64xx-sk
-TI Beaglebone Black,beaglebone-yocto
-TI Beaglebone Black Wireless,beaglebone-yocto
+:ref:`STM32MP157 Discovery Kit <ref-rm_board_stm32mp1-disco>`,stm32mp1-disco
+:ref:`TI AM64x SKEVM <ref-rm_board_am64xx-sk>`,am64xx-sk
+:ref:`TI Beaglebone Black <ref-rm_board_beaglebone-yocto>`,beaglebone-yocto
+:ref:`TI Beaglebone Black Wireless <ref-rm_board_beaglebone-yocto>`,beaglebone-yocto

--- a/source/reference-manual/boards/am64xx-sk.rst
+++ b/source/reference-manual/boards/am64xx-sk.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_am64xx-sk:
+
 Texas Instruments AM64x SKEVM
 =============================
 

--- a/source/reference-manual/boards/apalis-imx6.rst
+++ b/source/reference-manual/boards/apalis-imx6.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_boards_imx6ullevk-sec:
+
 Apalis iMX6 with the Ixora Carrier Board
 ========================================
 

--- a/source/reference-manual/boards/beagleboneblack.rst
+++ b/source/reference-manual/boards/beagleboneblack.rst
@@ -1,5 +1,9 @@
+.. _ref-rm_board_beaglebone-yocto:
+
 Beaglebone Black
 ================
+
+This tutorial covers both Beaglebone Black and Beaglebone Black Wireless.
 
 .. include:: generic-prepare.rst
 

--- a/source/reference-manual/boards/imx8mm.rst
+++ b/source/reference-manual/boards/imx8mm.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_imx8mmevk:
+
 i.MX 8M Mini Evaluation Kit
 ===========================
 

--- a/source/reference-manual/boards/imx8mq.rst
+++ b/source/reference-manual/boards/imx8mq.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_imx8mqevk:
+
 i.MX 8MQuad Evaluation Kit
 ==========================
 

--- a/source/reference-manual/boards/intel-corei7-intaller.rst
+++ b/source/reference-manual/boards/intel-corei7-intaller.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_intel-corei7-64:
+
 Intel Core i7 CPU (and later) - Installing into Internal Flash
 ==============================================================
 

--- a/source/reference-manual/boards/raspberrypi.rst
+++ b/source/reference-manual/boards/raspberrypi.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_rasbperrypi:
+
 Raspberry Pi 3/4
 ================
 

--- a/source/reference-manual/boards/stm32mp1.rst
+++ b/source/reference-manual/boards/stm32mp1.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_board_stm32mp1-disco:
+
 STM32MP157 Discovery Kit
 ========================
 

--- a/source/reference-manual/qemu/arm64.rst
+++ b/source/reference-manual/qemu/arm64.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_qemu_arm64:
+
 arm64
 =====
 

--- a/source/reference-manual/qemu/riscv64.rst
+++ b/source/reference-manual/qemu/riscv64.rst
@@ -1,3 +1,5 @@
+.. _ref-rm_qemu_riscv64:
+
 riscv64
 =======
 


### PR DESCRIPTION
Add a link from Supported Machines page to board flashing instruction
pages.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>