### PR TITLE
A pack of non-critical fixes

### DIFF
--- a/source/reference-manual/security/imx-generic-custom-keys.rst
+++ b/source/reference-manual/security/imx-generic-custom-keys.rst
@@ -13,8 +13,9 @@ In addition, the U-Boot project also includes a documentation on `Generating a
 fast authentication PKI tree`_.
 
 .. warning:: It is critical that the keys created in this process must be stored
-  in a secure and safe place. When the keys are fused to the board, that board
-  will only boot signed images. So the keys are required in future steps.
+  in a secure and safe place. Once the keys are fused to the board and it is
+  closed, that board will only boot signed images. So the keys are required in
+  future steps.
 
 Generate the MfgTools scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,23 +34,19 @@ configures the board to only boot signed images.
 
 .. prompt:: bash host:~$
 
-    export KEY_PATH=/path-to-key-files
+    export KEY_FILE=/path-to-key-files/<efusefile>
 
 3. Generate the script to fuse the board
 
 .. prompt:: bash host:~$
 
-      cd lmp-tools/
-      cd security/imx6ull
-      ./gen_fuse.sh -s $KEY_PATH
+      ./lmp-tools/security/<soc>/gen_fuse.sh -s $KEY_FILE -d ./fuse.uuu
 
 4. Generate the script to close the board
 
 .. prompt:: bash host:~$
 
-      cd lmp-tools/
-      cd security/imx6ull
-      ./gen_close.sh -s $KEY_PATH
+      ./lmp-tools/security/<soc>/gen_close.sh -s $KEY_FILE -d ./close.uuu
 
 5. Install the scripts to the ``meta-subscriber-overrides``:
 

--- a/source/reference-manual/security/secure-boot-imx6ullevk-sec.rst
+++ b/source/reference-manual/security/secure-boot-imx6ullevk-sec.rst
@@ -6,7 +6,7 @@ NXP iMX6ULL-EVK with secure boot enabled by FoundriesFactory
 ============================================================
 
 The machine ``imx6ullevk-sec`` is the ``imx6ullevk`` machine configured to have
-segure boot enabled by default.
+secure boot enabled by default.
 
 The purpose of this machine is to gather the needed configuration to enable
 secure boot and provide a set of artifacts to help in the process needed to have

--- a/source/reference-manual/security/secure-elements/secure-element.050.rst
+++ b/source/reference-manual/security/secure-elements/secure-element.050.rst
@@ -203,7 +203,7 @@ The *keys* however are retrieved via a pkcs#11 key generation request to the cry
    https://www.nxp.com.cn/docs/en/application-note/AN12660.pdf
 
 .. _NXP SE05x T=1 Over I2C Specification:
-   https://www.nxp.com/webapp/Download?colCode=UM11225&location=null
+   https://www.nxp.com/docs/en/user-guide/UM11225.pdf
 
 .. _Card Specification 2.3.1:
    https://globalplatform.org/specs-library/card-specification-v2-3-1/


### PR DESCRIPTION
- fix typo in secure-boot-imx6ullevk-sec.rst
- fix a directory name and a path to the fuse key in imx-generic-custom-keys.rst
- fix a link to the "NXP SE05x T=1 Over I2C Specification" document (https://foundriesio.atlassian.net/browse/FS-843)