### PR TITLE
tutorials: Removing -f <factory>

### DIFF
--- a/source/tutorials/configuring-and-sharing-volumes/dynamic-configuration-file.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/dynamic-configuration-file.rst
@@ -22,7 +22,7 @@ Use ``fioctl`` on your host machine to remember your device name:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ fioctl devices list -f <factory>
+    host:~$ fioctl devices list
 
 **Example Output**:
 

--- a/source/tutorials/creating-first-target/what-is-a-target.rst
+++ b/source/tutorials/creating-first-target/what-is-a-target.rst
@@ -45,7 +45,7 @@ It also lists what **Target** is installed in each device.
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ fioctl status -f <factory>
+    host:~$ fioctl status
 
 **Example Output**:
 
@@ -66,7 +66,7 @@ Before you inspect **Target 4**, list all your targets available with the comman
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ fioctl targets list -f <factory>
+    host:~$ fioctl targets list
 
 **Example Output**:
 
@@ -94,7 +94,7 @@ Use this command to see a better overview of **Target 4**:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ fioctl targets show 4 -f <factory>
+    host:~$ fioctl targets show 4
 
 **Example Output**:
 


### PR DESCRIPTION
Andy suggested that in the newer tutorials because most customer will have just one Factory.

The ideia is to make it simple for new users.

Signed-off-by: Raul Muñoz <raul@foundries.io>