### PR TITLE
Supported boards: Raspberrypi-3 CM is no longer supported

### DIFF
--- a/source/_static/csv/supported-boards.csv
+++ b/source/_static/csv/supported-boards.csv
@@ -18,9 +18,9 @@ NXP Toradex Colibri-iMX7 (Aster),colibri-imx7-emmc
 :ref:`QEMU AARCH32 <ref-rm_qemu_arm>`,qemuarm
 :ref:`QEMU AARCH64 <ref-rm_qemu_arm64>`,qemuarm64
 :ref:`QEMU RISCV-64 <ref-rm_qemu_riscv64>`,qemuriscv64
-:ref:`Raspberry Pi3 (32 bit and CM) <ref-rm_board_rasbperrypi>`,raspberrypi3
+:ref:`Raspberry Pi3 (32 bit) <ref-rm_board_rasbperrypi>`,raspberrypi3
 :ref:`Raspberry Pi3/3B (64 bit) <ref-rm_board_rasbperrypi>`,raspberrypi3-64
-:ref:`Raspberry Pi4 <ref-rm_board_rasbperrypi>`,raspberrypi4-64
+:ref:`Raspberry Pi4 (and CM) <ref-rm_board_rasbperrypi>`,raspberrypi4-64
 SiFive HiFive Unleashed,freedom-u540
 :ref:`STM32MP157 Discovery Kit <ref-rm_board_stm32mp1-disco>`,stm32mp1-disco
 :ref:`TI AM64x SKEVM <ref-rm_board_am64xx-sk>`,am64xx-sk


### PR DESCRIPTION
We support Raspberrypi-4 CM instead

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>