### PR TITLE
[FFTK-1048] Stop partial pages being generated

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -196,7 +196,10 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['reference-manual/boards/*flashing.rst',
+                    'reference-manual/boards/*-prepare.rst',
+                    'reference-manual/boards/*note.rst',
+                    'reference-manual/security/imx-generic-custom-keys.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
Added files that are used in include directives to the `excluded_patterns` list
in `source/conf.py`.

Tested and verified fix locally.

This patch will close FFTK-1048

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>