### PR TITLE
Add high-level explanation of QEMU CLI

### DIFF
--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -46,6 +46,11 @@ Booting in QEMU
    ``lmp-qemu/``. You may want to save this as ``run.sh`` inside the
    directory for convenience
 
+.. note::
+    The QEMU CLI passes the necessary flags and parameters to the
+    appropriate qemu-system command, such as image, CPU, network, and other device
+    information. For specifics, consult `QEMU's Documentation. <https://www.qemu.org/docs/master/index.html>`_
+
 Booting Graphically
 -------------------
 
@@ -57,4 +62,5 @@ Wayland/Weston), the following flags need to be added to the QEMU CLI:
      |QEMU_GUI_FLAGS|
 
 The ``-nographic`` flag must also be removed from the QEMU CLI.
+
 


### PR DESCRIPTION
Added a brief explanatory note of the QEMU CLI to start the image, and
included a link to QEMU's documentation. A more detailed explanation
could always be added later.

Checked that content appeared as intended when rendered as html.
Link was checked to ensure it was correct.

This addresses Jira FFTK-1037.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>