### PR TITLE
Add tip to check the qemu firmware blob

### DIFF
--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -33,6 +33,11 @@ Booting in QEMU
 
         |ARTIFACT_COMMANDS|
 
+.. tip::
+    When using ``>`` (redirect) to save the firmware blob, any error message
+    will be written to a text file with the same name. You can run the ``file``
+    utility to print whether it is an executable, as desired, or a txt/xml file.
+    
 #. The directory tree should now look like this
 
    .. parsed-literal::


### PR DESCRIPTION
Added a tip admonition for the QEMU instruction template to check that
the file is a firmware blob or not. This was based off of feedback we
received.

Built html to check that content rendered.

This applies to Jira 1036

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>