### PR TITLE
security: Improved instructions on offline keys

### DIFF
--- a/source/reference-manual/security/authentication-xilinx.rst
+++ b/source/reference-manual/security/authentication-xilinx.rst
@@ -249,7 +249,7 @@ For more information on registering the PUF and how it is used by OP-TEE for gen
    https://www.xilinx.com/support/documentation/application_notes/xapp1333-external-storage-puf.pdf
 
 .. _bitstream-signed:
-   https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed_git.bb
+   https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed.bb
 
 .. _lmp-tools:
    https://github.com/foundriesio/lmp-tools/tree/master/security/zynqmp


### PR DESCRIPTION
The information about the e-mail is dated, the e-mail notification no
longer contains the location to a one time download of TUF keys. This is
now possible through `fioctl keys rotate-root --initial` . The reference
to the first root key has been changed to `first` instead of `offline` .

Signed-off-by: Eric Bode <eric.bode@foundries.io>