### PR TITLE
reference-manual: fix token scope for wireguard server

### DIFF
--- a/source/reference-manual/remote-access/wireguard.rst
+++ b/source/reference-manual/remote-access/wireguard.rst
@@ -35,7 +35,7 @@ Create an API token for this service at https://app.foundries.io/settings/tokens
 
 .. note::
 
-   Your API token needs to have at least ``devices:read`` scope for this
+   Your API token needs to have at least ``devices:read-update`` scope for this
    guide. Read :ref:`ref-api-access` for more details.
 
 Clone VPN server code::


### PR DESCRIPTION
When starting wireguard server, token scope must be at least
"devices:read-update". Token with scope "devices:read" will generate the
followig error:

ERROR: Unable to configure factory: HTTP_403
"Credential used must include one of these scopes: <factory-name>:devices:read-update"

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>