### PR TITLE
rm: security: dg: align a device key type with lmp-dev-reg

### DIFF
--- a/source/reference-manual/security/device-gateway.rst
+++ b/source/reference-manual/security/device-gateway.rst
@@ -186,7 +186,7 @@ Create a directory for offline device key and certificate.
 Generate a private key
 ::
 
-    openssl ecparam -genkey -name secp521r1 -noout -out devices/offline-device/pkey.pem
+    openssl ecparam -genkey -name prime256v1 -out devices/offline-device/pkey.pem
 
 
 Set offline Device certificate config


### PR DESCRIPTION
Align a type of an offline device private key with the type
used by the default/LmP registration utility (lmp-device-register).

Signed-off-by: Mike Sul <mike.sul@foundries.io>