### PR TITLE
Update copyright range into 2022

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -169,7 +169,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'FoundriesFactory'
-copyright = '2017-2021, Foundries.io, Ltd'
+copyright = '2017-2022, Foundries.io, Ltd'
 author = 'Foundries.io, Ltd.'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
The copyright statement's date range is hard-coded, and has now been
updated for year 2022.

Html was built locally to verify change.

No issue linked, due to this being a small catch and fix.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>