### PR TITLE
compose-app: reference to wrong file

### DIFF
--- a/source/tutorials/compose-app/compose-app-mosquitto-broker.rst
+++ b/source/tutorials/compose-app/compose-app-mosquitto-broker.rst
@@ -44,7 +44,7 @@ Example output:
          ├── httpd.sh
          └── shellhttpd.conf
 
-Check the content of your ``mosquitto/docker-build.conf`` file:
+Check the content of your ``mosquitto/docker-compose.yml`` file:
 
 .. prompt:: bash host:~$, auto
 


### PR DESCRIPTION
Just a simple typo in the doc. It referenced a wrong file. 

Signed-off-by: Eric Bode <eric.bode@foundries.io>