### PR TITLE
wireguard: Clarify token scope requirements

### DIFF
--- a/source/reference-manual/remote-access/wireguard.rst
+++ b/source/reference-manual/remote-access/wireguard.rst
@@ -35,8 +35,9 @@ Create an API token for this service at https://app.foundries.io/settings/tokens
 
 .. note::
 
-   Your API token needs to have at least ``devices:read`` scope for this
-   guide. Read :ref:`ref-api-access` for more details.
+   Your API token needs to have the ``devices:read-update`` scope
+   for the initial ``enable`` command. After that, the token only
+   needs ``devices:read`` scope.
 
 Clone VPN server code::
 


### PR DESCRIPTION
Until we smooth out this flow with oauth2, we need to explain this
better.

Signed-off-by: Andy Doan <andy@foundries.io>