### PR TITLE
rm: security: se05x: move note to avoid confusion

### DIFF
--- a/source/reference-manual/security/secure-elements/se050-enablement.rst
+++ b/source/reference-manual/security/secure-elements/se050-enablement.rst
@@ -7,11 +7,6 @@ This section demonstrates how to enable the SE05X middleware in
 ``meta-subscriber-overrides``.
 
 .. note::
-    Please be aware that at this moment only ``imx6ullevk`` and
-    ``imx8mm-lpddr4-evk`` support SE05X integration without extra changes in
-    LmP.
-
-.. note::
     This procedure is valid for boards running OP-TEE 3.15.0.
 
 Enable the `se05x` MACHINE_FEATURES for the target machine and provide the
@@ -43,6 +38,11 @@ created since v85.
 Push the changes to the ``meta-subscriber-overrides`` repository to trigger a
 new build with SE05X support enabled. Be aware that an image created with SE05X
 enabled does not boot on boards without the SE05X properly attached.
+
+.. note::
+    Please be aware that at this moment only ``imx6ullevk`` and
+    ``imx8mm-lpddr4-evk`` support SE05X integration without extra changes in
+    LmP.
 
 Special cases
 -------------


### PR DESCRIPTION
The note that about boards that support se05x integration without
changes in LmP might lead to the conclusion that the change in
meta-subscriber-overrides is not needed for these boards, so move
this note to avoid this.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>