### PR TITLE
ota: Add more details about targets

### DIFF
--- a/source/reference-manual/ota/ci-targets.rst
+++ b/source/reference-manual/ota/ci-targets.rst
@@ -1,0 +1,80 @@
+.. _ref-ci-targets:
+
+CI Targets
+==========
+
+The point of the Factory is to create Targets. The magic of the
+Factory is how a simple ``git push`` can make this all happen. Because
+of how easy these are to create, there is another type of Target,
+:ref:`Production Targets <ref-production-targets>`, that are intended
+to be used for production devices. However, it's almost always
+originally created by CI when:
+
+ * A change is pushed to source.foundries.io
+ * A CI job is triggered in ci.foundries.io
+ * The CI job signs the resulting TUF targets.json with the Factory's
+   "online" targets signing key.
+
+The online targets signing key ID can be seen in the TUF root
+metadata:
+
+.. code-block:: bash
+
+  $ fioctl get https://api.foundries.io/ota/repo/<FACTORY>/api/v1/user_repo/root.json \
+  | jq '.signed.roles.targets.keyids[0]'
+
+Due to the number of changes and development branches a typical
+customer may have, the TUF targets metadata can grow to include large
+numbers of Targets. There are two ways these are dealt with:
+
+ * Condensed Targets
+ * Target Pruning
+
+Condensed Targets
+-----------------
+
+Each device is configured to take updates for Targets that include
+a specific tag. Because of this, the most of the Targets in the
+CI targets.json are aren't relevant and can be ignored by the device.
+In order to provide smaller TUF metadata payloads, the Foundries
+back-end employs a trick referred to as "condensed targets".
+
+Condensed Targets are produced by taking the raw CI version and then
+producing condensed versions for each unique tag. For example, the
+raw targets.json might include::
+
+  version=1, tag=master
+  version=2, tag=devel
+  version=3, tag=devel
+  version=4, tag=devel,experimental
+
+The back-end will actually produce three different condensed versions
+that are each signed with the Factory's online targets signing key::
+
+  # targets-master.json
+  version=1, tag=master
+
+  # targets-devel.json
+  version=2, tag=devel
+  version=3, tag=devel
+
+  # targets-experimental.json
+  version=3, tag=experimexperimental
+  version=4, tag=experimental
+
+The :ref:`device gateway <ref-ota-architecture>` is then able to serve
+an optimized targets.json to each CI device.
+
+Target Pruning
+--------------
+
+Each successful build appends a Target to targets.json. Eventually
+it grows too large and users will see an error in CI::
+
+  Publishing local TUF targets to the remote TUF repository
+  == 2022-03-24 00:44:18 Running: garage-sign targets push --repo /root/tmp.gkfCEF
+  |  An error occurred
+  |  com.advancedtelematic.libtuf.http.CliHttpClient$CliHttpClientError: ReposerverHttpClient|PUT|http/413|https://api.foundries.io/ota/repo/andy-corp/api/v1/user_repo/targets%7C<html>
+  |  <head><title>413 Request Entity Too Large</title></head>
+
+When this happens, it's time to :ref:`prune targets <ref-troubleshooting_request-entity-too-large>`.

--- a/source/reference-manual/ota/ci-targets.rst
+++ b/source/reference-manual/ota/ci-targets.rst
@@ -35,7 +35,7 @@ Condensed Targets
 
 Each device is configured to take updates for Targets that include
 a specific tag. Because of this, the most of the Targets in the
-CI targets.json are aren't relevant and can be ignored by the device.
+CI ``targets.json`` aren't relevant and can be ignored by the device.
 In order to provide smaller TUF metadata payloads, the Foundries
 back-end employs a trick referred to as "condensed targets".
 

--- a/source/reference-manual/ota/ci-targets.rst
+++ b/source/reference-manual/ota/ci-targets.rst
@@ -4,7 +4,7 @@ CI Targets
 ==========
 
 The point of the Factory is to create Targets. The magic of the
-Factory is how a simple ``git push`` can make this all happen. Because
+Factory is how a ``git push`` can make this all happen. Because
 of how easy these are to create, there is another type of Target,
 :ref:`Production Targets <ref-production-targets>`, that are intended
 to be used for production devices. However, it's almost always

--- a/source/reference-manual/ota/ci-targets.rst
+++ b/source/reference-manual/ota/ci-targets.rst
@@ -3,8 +3,8 @@
 CI Targets
 ==========
 
-The point of the Factory is to create Targets. The magic of the
-Factory is how a ``git push`` can make this all happen. Because
+The point of FoundriesFactory is to create Targets. The magic
+is how a ``git push`` can make this all happen. Because
 of how easy these are to create, there is another type of Target,
 :ref:`Production Targets <ref-production-targets>`, that are intended
 to be used for production devices. However, it's almost always

--- a/source/reference-manual/ota/ci-targets.rst
+++ b/source/reference-manual/ota/ci-targets.rst
@@ -12,7 +12,7 @@ originally created by CI when:
 
  * A change is pushed to source.foundries.io
  * A CI job is triggered in ci.foundries.io
- * The CI job signs the resulting TUF targets.json with the Factory's
+ * The CI job signs the resulting TUF ``targets.json`` with the Factory's
    "online" targets signing key.
 
 The online targets signing key ID can be seen in the TUF root

--- a/source/reference-manual/ota/ota.rst
+++ b/source/reference-manual/ota/ota.rst
@@ -12,5 +12,7 @@ Over the Air Updates
    device-tags
    advanced-tagging
    configuring
+   targets
+   ci-targets
    production-targets
    static-deltas

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -80,8 +80,8 @@ stanzas describe the intent. Then take a high-level view of the fleet:
     46      1        `fioctl targets show 46`
     112     1        `fioctl targets show 112`
 
-This will show what Targets are active in the field. Then take a look
-at a Target:
+This will show all Targets active in the field. Now take a look
+at a specific Target:
 
 .. code-block:: bash
 

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -42,7 +42,7 @@ is where you can start to visualize a Factory. The
 CI what it's supposed to build when changes hit source.foundries.io.
 The default factory-definition.yml tell CI:
 
- * If an LMP change (lmp-manifest.git or meta-subscriber-overrides.git)
+ * If an LmP change (lmp-manifest.git or meta-subscriber-overrides.git)
    comes in on the master branch, do a Yocto build and tag it with
    "master".
 

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -102,7 +102,7 @@ at a Target:
         ---          ----
         shellhttpd   sha256:e4a7b3a31c0126d28aaf75e1b8b6e83c7afd160b110267530b8572ce192160da
 
-This command gives the exact details of the Target including the CI
+This command gives the exact details of the Target, including the CI
 change that produced it.
 
 .. _The Update Framework:

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -1,0 +1,109 @@
+.. _ref-targets:
+
+Targets Overview
+================
+
+Perhaps the most important goal of a FoundriesFactory is to deliver
+immutable software updates to devices. This is achieved by using the
+`The Update Framework`_ (TUF). The central piece to TUF is the notion
+of a Target. A Target defines a cryptographically verifiable
+description of the software a device should run. A simplified example
+could be::
+
+ "raspberrypi3-64-lmp-42" : {
+    "hashes" : {"sha256" : "0xdeadbeef"},
+    "custom" : {
+      "version" : "42"
+      "docker_compose_apps" : {
+        "shellhttpd" : {
+          "uri" : "hub.foundries.io/andy-corp/shellhttpd@sha256:0xdeadbeef"
+        }
+      },
+      "hardwareIds" : ["raspberrypi3-64"],
+      "tags" : ["master"],
+    }
+  }
+
+This Target specifies some important bits of information:
+
+ * This is build ``42``
+ * The immutable OSTree hash of the base image is ``0xdeadbeef``
+ * The Compose App, ``shellhttpd``, is part of the Target.
+
+The Target is the goal. Developers push changes to Git in hopes of
+building a Target. Devices look to the OTA system for the latest
+Target they should run. Operators oversee the intersection of these
+goals.
+
+The point of the Factory is to create Targets. The magic of the
+Factory is how a simple ``git push`` can make this all happen and
+is where you can start to visualize a Factory. The
+:ref:`Factory Definition <ref-factory-definition>` file instructs
+CI what it's supposed to build when changes hit source.foundries.io.
+The default factory-definition.yml tell CI:
+
+ * If an LMP change (lmp-manifest.git or meta-subscriber-overrides.git)
+   comes in on the master branch, do a Yocto build and tag it with
+   "master".
+
+ * If a container change (containers.git) comes in on master branch,
+   do a container build and tag it with master.
+
+However, this can grow much :ref:`more complex <ref-advanced-tagging>`.
+
+CI must also take into account that Targets require both an OSTree
+image **and** Compose Apps. This turns out to be a fairly simple
+calculation. CI looks at the previous Target for a given tag. In
+the case of Yocto, it will copy the Compose Apps defined for it.
+In the case of a container build, it will copy the OSTree hash. In
+this way, there aren't "container targets" and "Yocto targets". There
+are only Targets.
+
+Visualizing a Factory
+---------------------
+
+Start with ``factory-config.yml`` to understand the intent. Then take
+a high-level view of the fleet:
+
+.. code-block:: bash
+
+  $ fioctl status
+  Total number of devices: 2
+
+  TAG     DEVICES  UP TO DATE  ONLINE
+  ---     -------  ----------  ------
+  master  2        1           1
+
+  ## Tag: master
+    TARGET  DEVICES  DETAILS
+    ------  -------  -------
+    46      1        `fioctl targets show 46`
+    112     1        `fioctl targets show 112`
+
+This will show what Targets are active in the field. Then take a look
+at a Target:
+
+.. code-block:: bash
+
+ $ fioctl targets show 46
+ CI:    https://ci.foundries.io/projects/andy-corp/lmp/builds/46/
+
+ ## Target: intel-corei7-64-lmp-46-master
+        Created:       2022-03-22T15:23:03Z
+        Tags:          master
+        OSTree Hash:   8f8a74e0fac31c1c3f43d737246e7320d453c377c6724c398a506b857d224e55
+
+        Source:
+            https://source.foundries.io/factories/andy-corp/lmp-manifest.git/commit/?id=aa36b74580d64f8754d42817e534004c05f80cf7
+            https://source.foundries.io/factories/andy-corp/meta-subscriber-overrides.git/commit/?id=d56ae6a677316bf1c8544cf9228632a59fe3d991
+            https://source.foundries.io/factories/andy-corp/containers.git/commit/?id=749aac2cc30c572769b702498373505dac1da7ed
+
+        APP          HASH
+        ---          ----
+        shellhttpd   sha256:e4a7b3a31c0126d28aaf75e1b8b6e83c7afd160b110267530b8572ce192160da
+
+This command gives the exact details of the Target including the CI
+change that produced it.
+
+.. _The Update Framework:
+   https://theupdateframework.com/

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -62,8 +62,8 @@ are only Targets.
 Visualizing a Factory
 ---------------------
 
-Start with ``factory-config.yml`` to understand the intent. Then take
-a high-level view of the fleet:
+Start with ``factory-config.yml``. The ``tagging`` and ``ref_options``
+stanzas describe the intent. Then take a high-level view of the fleet:
 
 .. code-block:: bash
 

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -40,7 +40,7 @@ Factory is how a simple ``git push`` can make this all happen and
 is where you can start to visualize a Factory. The
 :ref:`Factory Definition <ref-factory-definition>` file instructs
 CI what it's supposed to build when changes hit source.foundries.io.
-The default factory-definition.yml tell CI:
+The default factory-config.yml tells CI:
 
  * If an LmP change (lmp-manifest.git or meta-subscriber-overrides.git)
    comes in on the master branch, do a platform build and tag it with

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -43,7 +43,7 @@ CI what it's supposed to build when changes hit source.foundries.io.
 The default factory-definition.yml tell CI:
 
  * If an LmP change (lmp-manifest.git or meta-subscriber-overrides.git)
-   comes in on the master branch, do a Yocto build and tag it with
+   comes in on the master branch, do a platform build and tag it with
    "master".
 
  * If a container change (containers.git) comes in on master branch,
@@ -54,9 +54,9 @@ However, this can grow much :ref:`more complex <ref-advanced-tagging>`.
 CI must also take into account that Targets require both an OSTree
 image **and** Compose Apps. This turns out to be a fairly simple
 calculation. CI looks at the previous Target for a given tag. In
-the case of Yocto, it will copy the Compose Apps defined for it.
+the case of a platform build, it will copy the Compose Apps defined for it.
 In the case of a container build, it will copy the OSTree hash. In
-this way, there aren't "container targets" and "Yocto targets". There
+this way, there aren't "container targets" and "platform targets". There
 are only Targets.
 
 Visualizing a Factory


### PR DESCRIPTION
The goal was to talk about condensed targets. However, that was
difficult without first introducing the generic concept of Targets and
then diving into "ci targets".

The generic targets doc was largely lifted from my "What a Target"
blog:

 https://foundries.io/insights/blog/2020/05/14/whats-a-target/

Signed-off-by: Andy Doan <andy@foundries.io>