### PR TITLE
rm: secure-boot-imx: refer to signed spl

### DIFF
--- a/source/reference-manual/security/secure-boot-imx-habv4.rst
+++ b/source/reference-manual/security/secure-boot-imx-habv4.rst
@@ -164,7 +164,7 @@ Alternatively, use the kernel to program the A-core fuses using SDP via NXP's Un
 
         uuu_version 1.2.39
 
-        SDP: boot -f imx-boot-mfgtool
+        SDP: boot -f imx-boot-mfgtool.signed
 
         SDPU: delay 1000
         SDPV: write -f u-boot-mfgtool.itb


### PR DESCRIPTION
Our fusing scripts always use the signed spl so change
the docs accordingly.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>