### PR TITLE
Fix broken link in secure-elemewnt.050.rst

### DIFF
--- a/source/reference-manual/security/secure-elements/secure-element.050.rst
+++ b/source/reference-manual/security/secure-elements/secure-element.050.rst
@@ -302,7 +302,7 @@ This diagram summarizes the options discussed:
    https://www.nxp.com/products/security-and-authentication/authentication/edgelock-se050-plug-trust-secure-element-family-enhanced-iot-security-with-maximum-flexibility:SE050?tab=Design_Tools_Tab
 
 .. _scp03:
-   https://u-boot.readthedocs.io/en/latest/usage/scp03.html
+   https://u-boot.readthedocs.io/en/latest/usage/cmd/scp03.html
 
 .. _OP-TEE sanity tests:
     https://optee.readthedocs.io/en/latest/building/gits/optee_test.html


### PR DESCRIPTION
Link check was failing due to a link pointing to a non-existent external
doc page, it now references the correct page.

Ran linkcheck and viewed rendered html page to validate change.

No issue created as this was a minor fix.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>