### PR TITLE
Fix/credentials url

### DIFF
--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -138,9 +138,9 @@ credentials for interacting with Factory APIs:
 
    host:~$ fioctl login
      Please visit:
-     
-     https://app.foundries.io/settings/tokens/
-     
+
+     https://app.foundries.io/settings/credentials/
+
      and create a new "Application Credential" to provide inputs below.
      
      Client ID:
@@ -150,7 +150,7 @@ credentials for interacting with Factory APIs:
 Application Credentials
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Go to `Tokens <https://app.foundries.io/settings/tokens/>`_ and create a new **Application Credentials** by clicking on 
+Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`_ and create a new **Application Credentials** by clicking on
 :guilabel:`+ New Credentials`.
 
 .. figure:: /_static/install-fioctl/application_credentials.png
@@ -191,9 +191,9 @@ Use the Client ID and Secret to finish the fioctl login.
 
    host:~$ fioctl login
      Please visit:
-     
-     https://app.foundries.io/settings/tokens/
-     
+
+     https://app.foundries.io/settings/credentials/
+
      and create a new "Application Credential" to provide inputs below.
      
      Client ID:

--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -150,7 +150,7 @@ credentials for interacting with Factory APIs:
 Application Credentials
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`_ and create a new **Application Credentials** by clicking on
+Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`_ and create a new **Application Credential** by clicking on
 :guilabel:`+ New Credentials`.
 
 .. figure:: /_static/install-fioctl/application_credentials.png

--- a/source/reference-manual/factory/api-access.rst
+++ b/source/reference-manual/factory/api-access.rst
@@ -76,6 +76,9 @@ targets:read-update
 .. _User tokens:
    https://app.foundries.io/settings/tokens/
 
+.. _Application credentials:
+   https://app.foundries.io/settings/credentials/
+
 .. _REST APIs:
    https://api.foundries.io/ota/
 


### PR DESCRIPTION
Due to a new layout of the settings pages, application credentials now have their own dedicated page.

I plan to deploy those changes on Monday, and I also sent a PR to update fioctl command help/description.

We might have to take a new screenshot of the settings page though.