### PR TITLE
css: Fix list spacing

### DIFF
--- a/source/_static/theme_overrides.css
+++ b/source/_static/theme_overrides.css
@@ -95,6 +95,10 @@ p {
     font-size: 14px;
 }
 
+li {
+    font-size: 14px;
+}
+
 html.writer-html5 .rst-content dl.field-list>dt:after {
     content: initial;
 }


### PR DESCRIPTION
Our html lists have looked bad for a really long time. They use the
theme's default 16px found which is bigger than our paragraph body font
making lists look pretty awkward.

Signed-off-by: Andy Doan <andy@foundries.io>