### PR TITLE
Document use of the Docker credential helper

### DIFF
--- a/source/reference-manual/docker/configure-docker-helper.rst
+++ b/source/reference-manual/docker/configure-docker-helper.rst
@@ -16,9 +16,9 @@ To do this, run:
    sudo fioctl configure-docker
 
 This creates a symlink named ``docker-credential-fio`` in the directory of the docker client binary, pointing to ``fioctl``.
-Because the docker client is usually somewhere under ``/usr``, you will likely want to run it with root permission. The helper will then updates your Docker config file.
+Because the docker client is usually somewhere under ``/usr``, you will likely want to run it with root permission. The helper then updates your Docker config file.
 
-Now, docker commands will just work.
+Now, Docker commands will just work.
 
 Example:
 

--- a/source/reference-manual/docker/configure-docker-helper.rst
+++ b/source/reference-manual/docker/configure-docker-helper.rst
@@ -1,0 +1,29 @@
+.. _docker-credential-helper:
+
+Docker Credential Helper
+========================
+
+``fioctl`` has a Docker credential helper, providing easy access to hub.foundries.io.
+This enables the use of Docker commands from a personal computer, such as a laptop.
+
+.. note::
+   The :ref:`credentials<ref-api-access>` will need the “containers:read” scope to work with Docker.
+
+To do this, run:
+
+.. code:: bash
+
+   sudo fioctl configure-docker
+
+This creates a symlink named ``docker-credential-fio`` in the directory of the docker client binary, pointing to ``fioctl``.
+Because the docker client is usually somewhere under ``/usr``, you will likely want to run it with root permission. The helper will then updates your Docker config file.
+
+Now, docker commands will just work.
+
+Example:
+
+::
+
+   docker pull hub.foundries.io/FACTORY/shellhttpd
+
+You can also run ``fioctl configure-docker --help`` for more information and available flags.

--- a/source/reference-manual/docker/docker.rst
+++ b/source/reference-manual/docker/docker.rst
@@ -9,6 +9,7 @@ Docker
    docker-architecture
    containers
    container-secrets
+   configure-docker-helper
    private-registries
    compose-apps
    restorable-apps

--- a/source/reference-manual/factory/api-access.rst
+++ b/source/reference-manual/factory/api-access.rst
@@ -16,6 +16,10 @@ Tokens allow users to access:
 
 All tokens are created with scopes to help limit what they can do.
 
+.. note::
+   Fioctl has a :ref:`docker-credential-helper` which simplifies access to
+   hub.foundries.io.
+
 Common scopes
 -------------
 


### PR DESCRIPTION
Added a page, `reference-manual/docker/configure-docker-helper`,
updated the sections index, and included links between api-access
page and the new page.

We may want to move it elsewhere, or change some of the content of the
new page.

Checked rendered pages locally for formatting, and ran the linkcheck.

This applies to Jira FFTK 1350

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>