### PR TITLE
supported-boards: Remove Corstone 700

### DIFF
--- a/source/_static/csv/supported-boards.csv
+++ b/source/_static/csv/supported-boards.csv
@@ -1,6 +1,4 @@
 Device Name,MACHINE
-Arm Corstone-700 MPS3,corstone700-mps3
-Arm Corstone-700 FVP,corstone700-fvp
 Arm Cortex A5 DesignStart,a5ds
 :ref:`Arm Neoverse N1 System Development Platform (N1SDP) <ref-boards-x86>`,n1sdp
 :ref:`Intel NUC8 <ref-rm_board_intel-corei7-64>`,intel-corei7-64


### PR DESCRIPTION
Since [1] the machine Corstone 700 is removed.

https://git.yoctoproject.org/meta-arm/commit/meta-arm-bsp/conf/machine?h=kirkstone&id=92490b7fc5cd002f13337860ed34a608d4fba24b

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>