### PR TITLE
Add support for rendering Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following is the list of packages needed (can be incomplete):
 | sphinxcontrib-contentui |
 | sphinx_toolbox          |
 | sphinx-prompt           |
+| myst-parser             |
+
 
 ### Using virtualenv to Provide Requirements
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The following is the list of packages needed (can be incomplete):
 | sphinx-prompt           |
 | myst-parser             |
 
-
 ### Using virtualenv to Provide Requirements
 
 The recommended way to build documentation (in order to avoid messing with

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx_copybutton==0.3.0
 sphinxcontrib.asciinema==0.2.0
 sphinx_toolbox==2.12.1
 sphinx-prompt==1.4.0
+myst-parser

--- a/source/conf.py
+++ b/source/conf.py
@@ -105,6 +105,7 @@ extensions = [
     'sphinxcontrib.asciinema',
     'sphinx_toolbox.confval',
     'sphinx-prompt',
+    'myst_parser'
 ]
 
 copybutton_prompt_text = "$ "


### PR DESCRIPTION
The MyST parser extension was added to `requirements.txt` and
`source/conf.py`. It was also noted in the README. Details will be added
to CONTRIBUTING.md at a later date to summarize syntax. Please check in
with a Foundries.io technical writer before adding markdown.

Site was built and checked locally. Testing markdown pages were added
alongside restructured text, and included in the sidebar, before being
removed. No issues detected with simple markdown.

No issues to associate with this commit.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>