### PR TITLE
rm: faq: add note for adding a new user

### DIFF
--- a/source/reference-manual/troubleshooting/troubleshooting.rst
+++ b/source/reference-manual/troubleshooting/troubleshooting.rst
@@ -503,3 +503,6 @@ This is the ``USER_PASSWD`` to be added to the build as the new user password.
     "
 
 Remember to replace ``USER_PASSWD`` accordingly.
+
+After these changes, the files ``/usr/lib/passwd`` and ``/usr/lib/group`` should
+include the configuration for the new user.


### PR DESCRIPTION
Customers expect the new user to be shown in /etc while they show
in /usr/lib, so add a note for that.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>