### PR TITLE
 Clean up reference manual section on QEMU images

### DIFF
--- a/source/reference-manual/qemu/arm.rst
+++ b/source/reference-manual/qemu/arm.rst
@@ -28,4 +28,4 @@ Demo
 .. asciinema:: ./demo/arm.cast
 
 .. tip::
-    You can register your device following the steps from :ref:`gs-register`.
+    You can register your device by following the steps from :ref:`gs-register`.

--- a/source/reference-manual/qemu/arm64.rst
+++ b/source/reference-manual/qemu/arm64.rst
@@ -26,6 +26,4 @@ Demo
 .. asciinema:: ./demo/arm64.cast
 
 .. tip::
-    You can register your device
-    following the steps from
-    :ref:`gs-register`.
+    You can register your device by following the steps from :ref:`gs-register`.

--- a/source/reference-manual/qemu/generic-prepare.template
+++ b/source/reference-manual/qemu/generic-prepare.template
@@ -3,17 +3,14 @@ Preparation
 
 .. .. |ARCH| replace:: NULL
 
-Ensure you replace the ``<factory>`` placeholder below with the name of your
-Factory.
+Replace the ``<factory>`` placeholder below with the name of your Factory.
 
-#. Download necessary files from ``https://app.foundries.io/factories/<factory>/targets``
+#. Download the necessary files from ``https://app.foundries.io/factories/<factory>/targets``:
 
      a. Click the latest Target with the :guilabel:`platform-devel` trigger.
 
           .. figure:: /_static/qemu/generic-steps-1.png
              :width: 300
 
-     #. Expand the **run** in the :guilabel:`Runs` section which corresponds
-        with the name of the desired platform (E.g: |ARCH|) and **download the necessary
-        artifacts to boot that machine.**
+     b. Expand the **run** in the :guilabel:`Runs` section for the desired platform (E.g: |ARCH|) and **download the artifacts**.
 

--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -22,7 +22,7 @@ Booting in QEMU
 
      fioctl targets list
 
-#. Make a directory the artifacts and ``cd`` into it:
+#. Make a directory for the artifacts and ``cd`` into it:
 
    .. parsed-literal::
 

--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -1,4 +1,4 @@
-**Necessary artifacts**
+**Artifacts:**
 
 .. parsed-literal::
 
@@ -9,31 +9,33 @@
 Booting in QEMU
 ---------------
 
-.. warning:: These instructions require QEMU 5.2 or later.
+.. important:: These instructions require QEMU 5.2 or later.
+
+.. note::
+	Make sure to set the FIOCTL_FACTORY environment variable:
+
+    .. parsed-literal::
+
+        export FIOCTL_FACTORY=<factory>
 
 #. List available Targets and decide on which to boot::
 
      fioctl targets list
 
-.. note::
-	Make sure to set the FIOCTL_FACTORY environment variable:
-
-	export FIOCTL_FACTORY=<factory>
-
-#. Make a directory to store the artifacts and ``cd`` into it.
+#. Make a directory the artifacts and ``cd`` into it:
 
    .. parsed-literal::
 
           mkdir -p lmp-qemu/|ARCH|
           cd lmp-qemu/|ARCH|
 
-#. Download the **necessary artifacts** for |ARCH|, replace ``<target_number>`` with the target you would like to boot
+#. Download the **necessary artifacts** for |ARCH|, replacing ``<target_number>`` with the target you would like to boot:
 
    .. parsed-literal::
 
         |ARTIFACT_COMMANDS|
 
-#. The directory tree should now look like this
+#. The directory tree should now look like this:
 
    .. parsed-literal::
 
@@ -42,25 +44,22 @@ Booting in QEMU
             ├── lmp-factory-image-|MACHINE|.wic
             └── |FIRMWARE_BLOB|
 
-#. Run the QEMU script below against the artifacts inside of
-   ``lmp-qemu/``. You may want to save this as ``run.sh`` inside the
-   directory for convenience
+#. Run the QEMU script below against the artifacts inside of ``lmp-qemu/``.
+   You can save this as ``run.sh`` inside the directory for convenience.
 
 .. note::
-    The QEMU CLI passes the necessary flags and parameters to the
-    appropriate qemu-system command, such as image, CPU, network, and other device
-    information. For specifics, consult `QEMU's Documentation. <https://www.qemu.org/docs/master/index.html>`_
+    The QEMU CLI passes the necessary flags and parameters to the appropriate qemu-system command, such as image, CPU, network, and other device information.
+    For specifics, consult `QEMU's Documentation. <https://www.qemu.org/docs/master/index.html>`_
 
 Booting Graphically
 -------------------
 
-In order to boot QEMU with an OpenGL capable virtual GPU inside (required for
-Wayland/Weston), the following flags need to be added to the QEMU CLI:
+In order to boot QEMU with an OpenGL capable virtual GPU (required for Wayland/Weston), add the following flags to the QEMU CLI:
 
 .. parsed-literal::
 
      |QEMU_GUI_FLAGS|
 
-The ``-nographic`` flag must also be removed from the QEMU CLI.
+Do not copy the ``-nographic`` flag at the end of the QEMU CLI below.
 
 

--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -29,7 +29,7 @@ Booting in QEMU
           mkdir -p lmp-qemu/|ARCH|
           cd lmp-qemu/|ARCH|
 
-#. Download the **necessary artifacts** for |ARCH|, replacing ``<target_number>`` with the target you would like to boot:
+#. Download the artifacts needed for |ARCH|, replacing ``<target_number>`` with the target you would like to boot:
 
    .. parsed-literal::
 
@@ -48,7 +48,8 @@ Booting in QEMU
    You can save this as ``run.sh`` inside the directory for convenience.
 
 .. note::
-    The QEMU CLI passes the necessary flags and parameters to the appropriate qemu-system command, such as image, CPU, network, and other device information.
+    The QEMU CLI passes the necessary flags and parameters to the appropriate qemu-system command.
+    This includes path to the image, CPU, network, and other device information.
     For specifics, consult `QEMU's Documentation. <https://www.qemu.org/docs/master/index.html>`_
 
 Booting Graphically

--- a/source/reference-manual/qemu/qemu-ssh.template
+++ b/source/reference-manual/qemu/qemu-ssh.template
@@ -1,8 +1,7 @@
 .. _ref-rm_qemu_ssh:
 
-.. tip::
-    It is possible to access QEMU via SSH by appending these parameters to the
-    QEMU CLI command above:
+.. hint::
+    To access QEMU via SSH, append these parameters to the QEMU CLI command above:
 
     .. code-block::
 

--- a/source/reference-manual/qemu/riscv64.rst
+++ b/source/reference-manual/qemu/riscv64.rst
@@ -6,11 +6,8 @@ riscv64
 .. include:: riscv64-substitutions.inc
 .. include:: qemu-instructions.template
 
-.. warning::
-
-   qemu-system-riscv64 does not currently support this functionality.
-
-   https://patchwork.kernel.org/project/qemu-devel/cover/cover.1538683492.git.alistair.francis@wdc.com/
+.. attention::
+   qemu-system-riscv64 does not currently support `connecting to a PCIe host for graphics support <https://patchwork.kernel.org/project/qemu-devel/cover/cover.1538683492.git.alistair.francis@wdc.com/>`_
 
 QEMU CLI
 ^^^^^^^^
@@ -35,6 +32,4 @@ Demo
 .. asciinema:: ./demo/x86_64.cast
 
 .. tip::
-    You can register your device
-    following the steps from
-    :ref:`gs-register`.
+    You can register your device following the steps from :ref:`gs-register`.

--- a/source/reference-manual/qemu/x86_64.rst
+++ b/source/reference-manual/qemu/x86_64.rst
@@ -23,6 +23,4 @@ Demo
 .. asciinema:: ./demo/x86_64.cast
 
 .. tip::
-    You can register your device
-    following the steps from
-    :ref:`gs-register`.
+    You can register your device following the steps from :ref:`gs-register`.


### PR DESCRIPTION
As part of regular documentation maintenance, tidied up the pages and
templates, changed admonitions where appropriate, applied semantic newlines,
removed words that could be removed. No major changes to content made.

For QA: ran linkcheck, built and viewed content for intended rendering.

It may be wise to validate steps for each QEMU machine as part of a
separate task.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>