### PR TITLE
Cleanup getting-started install-fioctl page

### DIFF
--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -21,7 +21,7 @@ Installation
 ############
 
 .. note::
-   For installing on platforms outside of x86-64 and Apple's M1, you will need to :ref:`install from source <gs-fioctl-package-install>`.
+   For installing on platforms outside of x86-64, Apple's M1, and linux-arm64, you will need to :ref:`install from source <gs-fioctl-package-install>`.
 
 .. _gs-fioctl-manual-install:
 

--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -3,9 +3,10 @@
 Fioctl CLI Installation
 =======================
 
-:ref:`ref-fioctl` is a simple tool that interacts with the Foundries.io REST API
-for managing a Factory. It is based on the `ota-lite API
-<https://api.foundries.io/ota/>`_, also built by Foundries.io.
+:ref:`ref-fioctl` is a simple tool for interacting with the Foundries.io REST API.
+
+.. seealso::
+   Fioctl is based on Foundries.io's  `ota-lite API <https://api.foundries.io/ota/>`_.
 
 :ref:`ref-fioctl`, is used to manage:
 
@@ -19,22 +20,29 @@ for managing a Factory. It is based on the `ota-lite API
 Installation
 ############
 
+.. note::
+   For installing on platforms outside of x86-64 and Apple's M1, you will need to :ref:`install from source <gs-fioctl-package-install>`.
+
 .. _gs-fioctl-manual-install:
 
 Manual Installation
 ^^^^^^^^^^^^^^^^^^^
 
-We use `Github Releases`_ to distribute static X86_64 golang binaries.
+We use `Github Releases`_ to distribute static golang binaries.
+
+.. tip::
+   Repeating the following steps will overwrite an existing binary, useful for updating or changing version.
 
 .. tabs::
 
    .. group-tab:: Linux
+      
+      .. attention::
+        Make sure you have Curl installed.
 
-      1. Download a Linux binary from the `Github Releases`_ page to a directory
-         on your ``PATH``, make sure you have Curl installed
+      1. Download a Linux binary to a directory on your ``PATH``.
 
-         For example, to download version |fioctl_version| on Linux, define the 
-         version:
+         For example, to download version |fioctl_version| on Linux, define the version:
 
          .. parsed-literal::
 
@@ -52,16 +60,14 @@ We use `Github Releases`_ to distribute static X86_64 golang binaries.
 
             host:~$ sudo chmod +x /usr/local/bin/fioctl
 
-      You can execute this again in future to overwrite your binary, therefore
-      updating or changing your version.
-
    .. group-tab:: macOS
+      
+      .. attention::
+        Make sure you have Curl installed.
 
-      1. Download a Darwin binary from the `Github Releases`_ page to a directory
-         on your ``PATH``, make sure you have Curl installed
+      1. Download a Darwin binary from the `Github Releases`_ page to a directory on your ``PATH``.
 
-         For example, to download version |fioctl_version| on macOS, define the 
-         version:
+         For example, to download version |fioctl_version| on macOS, define the version:
 
          .. parsed-literal::
 
@@ -73,11 +79,9 @@ We use `Github Releases`_ to distribute static X86_64 golang binaries.
 
             host:~$ curl -o /usr/local/bin/fioctl -LO https://github.com/foundriesio/fioctl/releases/download/$FIOCTL_VERSION/fioctl-darwin-amd64
         
-         .. note::
+         .. important::
         
-            For MacOS running on a Apple M1 processor, replace
-            ``fioctl-darwin-amd64`` with ``fioctl-darwin-arm64``, and set
-            ``FIOCTL_VERSION`` to v0.21 or newer.
+            For MacOS running on a Apple M1 processor, replace ``fioctl-darwin-amd64`` with ``fioctl-darwin-arm64``, and set ``FIOCTL_VERSION`` to v0.21 or newer.
 
       2. Make the :ref:`ref-fioctl` binary executable:
 
@@ -85,8 +89,6 @@ We use `Github Releases`_ to distribute static X86_64 golang binaries.
 
             host:~$ sudo chmod +x /usr/local/bin/fioctl
 
-      You can execute this again in future to overwrite your binary, therefore
-      updating or changing your version.
 
    .. group-tab:: Windows
 
@@ -99,8 +101,7 @@ We use `Github Releases`_ to distribute static X86_64 golang binaries.
       7. Click ``New`` in the "Edit environment variable" menu.
       8. Enter the path to the folder in which you have placed :ref:`ref-fioctl`.
 
-         An example path string if installing to a folder on the desktop would
-         look like this.
+         An example path string if installing to a folder on the desktop would look like this.
 
          ``C:\Users\Gavin\Desktop\fio\bin``
 
@@ -112,15 +113,11 @@ We use `Github Releases`_ to distribute static X86_64 golang binaries.
 Install From Source
 ^^^^^^^^^^^^^^^^^^^
 
-.. note::
+.. attention::
 
-    This requires that you have Golang installed. See
-    https://golang.org/doc/install for instructions.
+    This requires that you have `Golang installed <https://golang.org/doc/install>`_.
 
-If you intend to use Fioctl on a non X86_64 platform (like a Raspberry
-Pi/Pinebook/Smartphone) such as ARM, RISC-V, PPC, etc. Fioctl can be compiled
-and installed from the latest sources and installed via Golang's own package
-manager; ``go get``:
+Fioctl can be compiled and installed from the latest source via Golang's own package manager; ``go get``:
 
 .. prompt:: bash host:~$, auto
 
@@ -130,9 +127,9 @@ manager; ``go get``:
 
 Authenticate fioctl
 ###################
-Now that :ref:`ref-fioctl` is installed, you must authenticate with our backend
-before you're able to use it. This requires you to generate OAuth2 application
-credentials for interacting with Factory APIs:
+
+With :ref:`ref-fioctl` installed, authenticate it with our backend.
+For this, you will generate OAuth2 application credentials for interacting with the FoundriesFactory API:
 
 .. prompt:: bash host:~$, auto
 
@@ -150,8 +147,7 @@ credentials for interacting with Factory APIs:
 Application Credentials
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`_ and create a new **Application Credential** by clicking on
-:guilabel:`+ New Credentials`.
+Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`_ and click on :guilabel:`+ New Credentials`.
 
 .. figure:: /_static/install-fioctl/application_credentials.png
    :width: 900
@@ -161,9 +157,8 @@ Go to `Application Credentials <https://app.foundries.io/settings/credentials/>`
 
 Complete with a **Description** and the **Expiration date** and select :guilabel:`next`.
 
-For fioctl, check the :guilabel:`Use for tools like fioctl` box and 
-select your **Factory**. Remember that you can revoke this access and set up a new credential later once you are
-familiar with the :ref:`ref-api-access`.
+For fioctl, check the :guilabel:`Use for tools like fioctl` box and select your **Factory**.
+You can revoke this access and set up a new credential later once you are familiar with the :ref:`ref-api-access`.
 
 .. figure:: /_static/install-fioctl/fioctl_token.png
    :width: 500
@@ -173,11 +168,9 @@ familiar with the :ref:`ref-api-access`.
 
 .. tip::
 
-   We recommend creating a new API token for each device you plan to use our
-   tools with. For example, if you intend to develop on multiple systems such
-   as a laptop and a desktop, you should create a new token for each, just as
-   you would with SSH keys. This way you can revoke tokens for individual systems,
-   should they be compromised.
+   We recommend creating a new API token for each computer you plan to use our tools with.
+   For example, if you intend to develop on both a laptop and a desktop, create a new token for each, as you would with SSH keys.
+   This way you can revoke tokens for individual systems, should they be compromised.
 
 Use the Client ID and Secret to finish the fioctl login.
 
@@ -228,9 +221,8 @@ It can be set using 3 different methods:
         host:~$ echo "factory: <factory>" >> $HOME/.config/fioctl.yaml
         host:~$ fioctl targets list
 
-.. note::
-   Refer to the :ref:`ref-fioctl` section of the documentation to learn more
-   about configuration.
+.. seealso::
+   :ref:`ref-fioctl` documentation.
 
 .. _AUR Package: https://aur.archlinux.org/packages/fioctl-bin
 .. _Scoop: https://scoop.sh/

--- a/source/index.rst
+++ b/source/index.rst
@@ -12,8 +12,8 @@ OE/Yocto Project, the Linux microPlatform™ and Docker®.
    :name: sec-learn
 
    getting-started/signup/index
-   getting-started/git-config/index
    getting-started/install-fioctl/index
+   getting-started/git-config/index
    getting-started/flash-device/index
    getting-started/register-device/index
 


### PR DESCRIPTION
Changes made to grammar, word usage, and admonition types. The sidebar
index page was modified so that install-fioctl came before the git page.
The git page assumes the user is familiar with generating a key,
which install-fioctl covers.

QA steps included running checklink and build, along with spellcheck.
The validity of the steps was not checked.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>