### PR TITLE
rm:ug: Sensitive review based on Kirkstone update

### DIFF
--- a/source/reference-manual/security/secure-boot-imx-habv4.rst
+++ b/source/reference-manual/security/secure-boot-imx-habv4.rst
@@ -366,7 +366,7 @@ If you are running with a *Cryptographic Acceleration and Assurance Module* devi
 
 So if the user-specific application requires any changes in the CAAM MID registers, it is necessary to add the “Unlock CAAM MID” command into the CSF file.
 
-Not doing so, since the CAAM will not have been configured for the proper MIDs, leaves some of the CAAM registers not accessible for writing and any attempt to write to them will cause system **core aborts**.
+Not doing so, since the CAAM will not have been configured for the proper MIDs, leaves some of the CAAM registers not accessible for writing and any attempt to write to them will cause system **core fails**.
 
 .. note::
 	The current NXP BSP implementation expects the CAAM registers to be unlocked when configuring the CAAM to operate in the non-secure TrustZone world. This applies when OP-TEE is enabled on the i.MX 6, i.MX 7, and i.MX 7ULP processors.

--- a/source/reference-manual/security/secure-elements/secure-element.050.rst
+++ b/source/reference-manual/security/secure-elements/secure-element.050.rst
@@ -66,7 +66,7 @@ provided by the SE05x; in particular all cryptographic operations have a softwar
 mirror implementation in OP-TEE: ECC, RSA, MAC, HASH, AES, 3DES and so forth.
 
 This meant that we could validate our integration using the OP-TEE crypto regression
-test suite from the `OP-TEE sanity tests`_
+test suite from the `OP-TEE tests`_
 
 The main advantage of using the SE05x in a product design which already runs a TEE
 is that all private keys programmed in the device's non volatile memory will never
@@ -82,7 +82,7 @@ session can access its objects for creation or deletion.
 OP-TEE Integration
 -------------------
 
-The SE05x standard physical interface is I2C typically configured as a slave running
+The SE05x standard physical interface is I2C typically configured as a target running
 in high speed mode (3.4Mbps). Since the SE05x could replace the OP-TEE default crypto
 operations (software), we chose to implement a native I2C driver so the SE05x
 could be accessed as early as possible.
@@ -304,7 +304,7 @@ This diagram summarizes the options discussed:
 .. _scp03:
    https://u-boot.readthedocs.io/en/latest/usage/cmd/scp03.html
 
-.. _OP-TEE sanity tests:
+.. _OP-TEE tests:
     https://optee.readthedocs.io/en/latest/building/gits/optee_test.html
 
 .. _mini package:

--- a/source/user-guide/fioctl/index.rst
+++ b/source/user-guide/fioctl/index.rst
@@ -13,7 +13,7 @@ Enabling/Disabling Apps
 -----------------------
 
 By default all apps defined in :term:`containers.git` for any given tag are
-enabled. To change this behaviour, a whitelist of apps can be given **per
+enabled. To change this behaviour, a list of allowed apps can be given **per
 device**, enabling only those apps that are in a comma separated list.
 
 Via Fioctl


### PR DESCRIPTION
The goal is to make sure we cover any variable being converted in Kirkstone.

While on this, change some words.

Sensitive review based on https://inclusivenaming.org/word-lists/no-change/

For I2C terms, following I2C revision 7 from https://www.nxp.com/docs/en/user-guide/UM10204.pdf

**master**: we are still converting the `master` branch on each repository, the documentation will follow the repository accordingly.


