### PR TITLE
Add readiness to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+## Readiness
+
+* [ ] Merge (pending reviews)
+* [ ] Merge after _date or event_
+* [ ] Draft
+
 ## Overview
 
 _Why merge this PR? What does it solve?_
@@ -27,4 +33,4 @@ _You can fill this out after opening the PR. "Did I..."_
 ## Comments
 
 _Any thing else that a maintainer/reviewer should know._
-_This could include a request to delay merge, issues, rational for approach, etc._
+_This could include potential issues, rational for approach, etc._


### PR DESCRIPTION
Added a section to the top of the PR template presenting checkboxes to
mark the "readiness" of the merge.

No QA steps taken, no related issue.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Overview

Current PR template does not include options to state readiness, and was suggested in PR #380. 
Adding this option explicitly may prevent undesired merges.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

* [x] Ready to merge (pending PR review).
