### PR TITLE
Remove RM Security:Overview from having own link in sidebar nav

### DIFF
--- a/source/reference-manual/security/security.rst
+++ b/source/reference-manual/security/security.rst
@@ -4,7 +4,7 @@ Security
 ========
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    secure-boot
    boot-software-updates
@@ -13,7 +13,7 @@ Security
 
 
 Overview
-========
+--------
 
 Security has multiple layers and dimensions. Such as:
 


### PR DESCRIPTION
The section header for overview was changed from top to level two.
Changes did not appear until a clean build was done.

For QA steps, links and rendering were checked. No content change, so
a reduced set of checks performed.

This will close Jira FFTK 1617.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview
The Security page in the reference manual had two top level headers, so that both "Security" and "Overview" showed up at the same level in the sidebar, while the overview section also showed up as a child/page section for security. There should only be one top level header on a page.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
