### PR TITLE
qemu-x86: use ovmf.secboot.qcow2 by default

### DIFF
--- a/source/reference-manual/linux/linux-wic-installer.rst
+++ b/source/reference-manual/linux/linux-wic-installer.rst
@@ -47,7 +47,7 @@ Create the virtual disk device that will be used as target with ``qemu-img``::
 
   $ qemu-img create -f raw disk.img 4G
 
-Download ``lmp-factory-image-intel-corei7-64.wic`` and ``ovmf.qcow2``
+Download ``lmp-factory-image-intel-corei7-64.wic`` and ``ovmf.secboot.qcow2``
 from your own Factory CI run, then run Qemu with the following arguments::
 
   $ qemu-system-x86_64 -device virtio-net-pci,netdev=net0,mac=52:54:00:12:35:02 \
@@ -56,7 +56,7 @@ from your own Factory CI run, then run Qemu with the following arguments::
       -drive if=none,id=hd,file=lmp-factory-image-intel-corei7-64.wic,format=raw \
       -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd \
       -drive if=none,id=hd2,file=disk.img,format=raw -device scsi-hd,drive=hd2 \
-      -drive if=pflash,format=qcow2,file=ovmf.qcow2 -no-reboot \
+      -drive if=pflash,format=qcow2,file=ovmf.secboot.qcow2 -no-reboot \
       -nographic -cpu kvm64 -enable-kvm -m 1024 -serial mon:stdio -serial null
 
 Now just follow the instructions provided by the installer in order to
@@ -70,5 +70,5 @@ up again, but using ``disk.img`` as the primary block device::
       -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
       -drive if=none,id=hd,file=disk.img,format=raw \
       -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd \
-      -drive if=pflash,format=qcow2,file=ovmf.qcow2 \
+      -drive if=pflash,format=qcow2,file=ovmf.secboot.qcow2 \
       -nographic -cpu kvm64 -enable-kvm -m 1024 -serial mon:stdio -serial null

--- a/source/reference-manual/qemu/demo/x86_64.cast
+++ b/source/reference-manual/qemu/demo/x86_64.cast
@@ -6,7 +6,7 @@
 [0.453104, "o", "l"]
 [0.573021, "o", "s"]
 [0.685379, "o", "\r\n\u001b[?2004l\r\u001b[?1l\u001b>"]
-[0.686036, "o", "lmp-factory-image-intel-corei7-64.wic  ovmf.qcow2  \u001b[0m\u001b[01;32mrun.sh\u001b[0m\r\n"]
+[0.686036, "o", "lmp-factory-image-intel-corei7-64.wic  ovmf.secboot.qcow2  \u001b[0m\u001b[01;32mrun.sh\u001b[0m\r\n"]
 [0.686278, "o", "\u001b]0;matthew@thinkpad:~/Downloads/qemufoundries/x86_64\u0007"]
 [0.686368, "o", "\u001b[?1h\u001b=\u001b[?2004h$ "]
 [1.245041, "o", "."]

--- a/source/reference-manual/qemu/x86_64-substitutions.inc
+++ b/source/reference-manual/qemu/x86_64-substitutions.inc
@@ -1,6 +1,6 @@
 .. |ARCH| replace:: x86_64
 .. |MACHINE| replace:: intel-corei7-64
-.. |FIRMWARE_BLOB| replace:: ovmf.qcow2
+.. |FIRMWARE_BLOB| replace:: ovmf.secboot.qcow2
 .. |QEMU_GUI_FLAGS| replace::
 
      -vga virtio -display gtk,gl=on

--- a/source/reference-manual/qemu/x86_64.rst
+++ b/source/reference-manual/qemu/x86_64.rst
@@ -12,7 +12,7 @@ QEMU CLI
      qemu-system-x86_64 -m 1024 -cpu kvm64 -enable-kvm -serial mon:stdio -serial null \
        -drive file=lmp-factory-image-intel-corei7-64.wic,format=raw,if=none,id=hd \
        -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd -device virtio-rng-pci \
-       -drive if=pflash,format=qcow2,file=ovmf.qcow2 \
+       -drive if=pflash,format=qcow2,file=ovmf.secboot.qcow2 \
        -net user,hostfwd=tcp::22223-:22 -net nic -nographic
 
 .. include:: qemu-ssh.template


### PR DESCRIPTION
Prefer the ovmf.secboot.qcow2 firmware by default as that allows
enabling and using UEFI Secure Boot.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Prefer the ovmf.secboot.qcow2 firmware by default as that allows enabling and using UEFI Secure Boot.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.