### PR TITLE
Fix broken links to Yocto Project documentation

### DIFF
--- a/source/reference-manual/linux/linux-building.rst
+++ b/source/reference-manual/linux/linux-building.rst
@@ -228,11 +228,11 @@ recommended for those new to either project.
 .. _Yocto Project main page:
    https://www.yoctoproject.org/
 .. _Yocto Project Quick Start Guide:
-   https://www.yoctoproject.org/docs/current/brief-yoctoprojectqs/brief-yoctoprojectqs.html
+   https://www.yoctoproject.org/docs/current/brief-yoctoprojectqs/
 .. _Yocto Project Reference Manual:
-   https://www.yoctoproject.org/docs/current/ref-manual/ref-manual.html
+   https://www.yoctoproject.org/docs/current/ref-manual/
 .. _BitBake Manual:
-   https://www.yoctoproject.org/docs/current/bitbake-user-manual/bitbake-user-manual.html
+   https://www.yoctoproject.org/docs/bitbake/
 
 .. _Google Repo:
    https://source.android.com/setup/develop/repo


### PR DESCRIPTION
Links were updated to point to available pages after YP doc site
changes.

QA: ran linkcheck.

No associated Jira issues.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

linkcheck was failing due to links to Yocto Project Documentation no longer being available.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments