### PR TITLE
Clarify user permissions for Docker config helper

### DIFF
--- a/source/reference-manual/docker/configure-docker-helper.rst
+++ b/source/reference-manual/docker/configure-docker-helper.rst
@@ -20,7 +20,12 @@ This creates a symlink named ``docker-credential-fio`` in the directory of the d
 .. important::
     Because the Docker client is usually somewhere under ``/usr``, you will want to run ``fioctl configure-docker`` with root permission.
 
-The helper then updates your Docker config file.
+The helper then updates `your` Docker config file, which is located under ``$HOME/.docker``.
+
+.. note::
+    The helper configures for the current `user` and not the entire `system`.
+    If you are logged in as root, then it would be in the root home directory, which you should generally avoid doing.
+
 Now, Docker commands will just work.
 
 Example:

--- a/source/reference-manual/docker/configure-docker-helper.rst
+++ b/source/reference-manual/docker/configure-docker-helper.rst
@@ -3,7 +3,7 @@
 Docker Credential Helper
 ========================
 
-``fioctl`` has a Docker credential helper, providing easy access to hub.foundries.io.
+``fioctl`` has a Docker credential helper, providing easier access to hub.foundries.io.
 This enables the use of Docker commands from a personal computer, such as a laptop.
 
 .. note::
@@ -16,8 +16,11 @@ To do this, run:
    sudo fioctl configure-docker
 
 This creates a symlink named ``docker-credential-fio`` in the directory of the docker client binary, pointing to ``fioctl``.
-Because the docker client is usually somewhere under ``/usr``, you will likely want to run it with root permission. The helper then updates your Docker config file.
 
+.. important::
+    Because the Docker client is usually somewhere under ``/usr``, you will want to run ``fioctl configure-docker`` with root permission.
+
+The helper then updates your Docker config file.
 Now, Docker commands will just work.
 
 Example:
@@ -26,4 +29,9 @@ Example:
 
    docker pull hub.foundries.io/FACTORY/shellhttpd
 
+.. important::
+   To run Docker commands without sudo, you will need to gain access to ``/var/run/docker.sock``.
+   You can do this by `adding yourself to the Docker group <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
+
 You can also run ``fioctl configure-docker --help`` for more information and available flags.
+


### PR DESCRIPTION
Two changes were made:
The use of sudo for the symlink step was changed to note that it is
specific to that cmd invocation specifically.
An additional admonition was added to draw attention to the need for
the user to belong to the docker group.

QA steps: make Linkcheck was ran, and the rendered html was checked.
Vale was ran to lint the content.

No related issue.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

A Slack discussion in infrastructure pointed out the need to clarify user permissions for docker, specifically around the docker config helper.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments
If I didn't quite hit the mark, let me know and I will make further changes.
