### PR TITLE
gs: Remove fioctl installation from source code

### DIFF
--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -20,9 +20,6 @@ Fioctl CLI Installation
 Installation
 ############
 
-.. note::
-   For installing on platforms outside of x86-64, Apple's M1, and linux-arm64, you will need to :ref:`install from source <gs-fioctl-package-install>`.
-
 .. _gs-fioctl-manual-install:
 
 Manual Installation
@@ -108,22 +105,6 @@ We use `Github Releases`_ to distribute static golang binaries.
       You should now be able to open ``cmd.exe`` or ``powershell.exe`` and type
       ``fioctl``.
 
-.. _gs-fioctl-package-install:
-
-Install From Source
-^^^^^^^^^^^^^^^^^^^
-
-.. attention::
-
-    This requires that you have `Golang installed <https://golang.org/doc/install>`_.
-
-Fioctl can be compiled and installed from the latest source via Golang's own package manager; ``go get``:
-
-.. prompt:: bash host:~$, auto
-
-   host:~$ go get github.com/foundriesio/fioctl
-
-.. _gs-fioctl-authenticate-fioctl:
 
 Authenticate fioctl
 ###################


### PR DESCRIPTION
Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>

## Readiness

* [x ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

The instruction does not work any more.

```
$ go get github.com/foundriesio/fioctl
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
$ go install github.com/foundriesio/fioctl@main
go: downloading github.com/foundriesio/fioctl v0.19.2-0.20220812084014-6d08d04faeef
go: github.com/foundriesio/fioctl@main (in github.com/foundriesio/fioctl@v0.19.2-0.20220812084014-6d08d04faeef):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
$ go version
go version go1.18.1 linux/amd64
```

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Avoid changing any header associated with a link/reference.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [x ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [x ] End message with sign off/DCO line (`-s, --signoff`).
  * [x ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x ] Request PR review by a technical writer and at least one peer.

## Comments
It removes a section and it might break some URL. I could not find any other cross reference or the URL being used from website repository. Which other docs should I remove the URL? (if any, please let me know)

URL being removed:
https://docs.foundries.io/latest/getting-started/install-fioctl/index.html#install-from-source