### PR TITLE
Fix incorrect indentation of .. warning:: label

### DIFF
--- a/source/reference-manual/security/secure-boot-stm32mp1.rst
+++ b/source/reference-manual/security/secure-boot-stm32mp1.rst
@@ -86,7 +86,7 @@ commands::
         OTP value 30: 38841b57
         OTP value 31: b7a16954
 
- .. warning::
+.. warning::
 
    Once the fuses have been programmed they can't be modified.
 


### PR DESCRIPTION
Because it's indented, it renders as part of the code block above it.

This is a trivial change so the normal PR template is skipped.
