### PR TITLE
Add latest to canonical url path

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -240,10 +240,14 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
+
+# Note that for Sphinx-RTD v0.6.0 or newer, 'html_baseurl' is used rather
+# than canonical_url
 html_theme_options = {
     'logo_only': True,
-    'canonical_url': 'https://docs.foundries.io/'
+    'canonical_url': 'https://docs.foundries.io/latest/'
 }
+
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
The new path is https://docs.foundries.io/latest/.

Note that this only addresses the issue of going forward, and does not completely solve the issue of older versions showing up in search results.

Built and rendered locally without issue.

No issues to tag, as this is a relatively minor change. (picked out from a larger effort)

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

This is part of a larger effort to address older doc versions from coming up in searches.
The commit does **not** address the issue with past releases however.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [] Avoid changing any header associated with a link/reference.
* [] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

