### PR TITLE
Fix broken link reference in rm:security

### DIFF
--- a/source/reference-manual/security/authentication-xilinx.rst
+++ b/source/reference-manual/security/authentication-xilinx.rst
@@ -240,8 +240,7 @@ For more information on registering the PUF and how it is used by OP-TEE for gen
    https://github.com/Xilinx/embeddedsw/tree/master/lib/sw_services/xilskey
 
 .. _documentation:
-   https://github.com/Xilinx/embeddedsw/blob/master/lib/sw_services/xilskey/doc/xilskey.pdf
-
+   https://docs.xilinx.com/r/en-US/oslib_rm/Xilinx-BSP-and-Libraries-Overview
 .. _XAPP1319:
    https://www.xilinx.com/support/documentation/application_notes/xapp1319-zynq-usp-prog-nvm.pdf
 


### PR DESCRIPTION
Updated reference-manual/security/authentication-xilinx to link to a listing of related documents, as the pdf we had been linking to is no longer available at that address, and could not be found. The information should be findable in the new link however.

Ran link-check and rendered the page. No errors were found.

This commit applies to Jira FFTK #1880

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

The broken link has been causing all doc builds to fail during `make linkcheck`. Changed the link to where I believe the information can be found still, if not with a bit more work. This will need to be verified. 

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments
