### PR TITLE
fix: remove slack references

### DIFF
--- a/source/user-guide/el2g.rst
+++ b/source/user-guide/el2g.rst
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
  * An :ref:`NXP SE05X secure element <ref-secure-elements>`
- * A FoundriesFactory that has been registered with EdgeLock 2GO. Please `contact our support team <https://foundriesio.atlassian.net/servicedesk/customer/portal/1/group/1/create/3>`_ or use Slack to arrange this.
+ * A FoundriesFactory that has been registered with EdgeLock 2GO. Please `contact our support team <https://foundriesio.atlassian.net/servicedesk/customer/portal/1/group/1/create/3>`_.
  * Access to your Factory PKI :ref:`root of trust <Root-of-trust>`.
 
 Enabling Auto-connect to Foundries.io


### PR DESCRIPTION
Signed-off-by: Milo Casagrande <milo@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

As per marketing request, we should remove Slack references when used for support purposes.

## Comments

It should be a trivia change, no QA tests have been run.