### PR TITLE
fix(docker): Change to hub-ui

### DIFF
--- a/source/tutorials/compose-app/compose-app-docker-container-image.rst
+++ b/source/tutorials/compose-app/compose-app-docker-container-image.rst
@@ -11,7 +11,7 @@ The file structure responsible for creating the Docker Container Image is:
 
 The combination of a top-level directory containing a ``Dockerfile`` will end-up 
 in a Docker Container Image. 
-It will be compiled by FoundriesFactory CI and published in your `Factory hub. <https://hub.foundries.io/>`_
+It will be compiled by FoundriesFactory CI and published in your `Factory hub. <https://hub-ui.foundries.io/>`_
 
 .. figure:: /_static/tutorials/compose-app/hub.png
    :width: 600

--- a/source/tutorials/creating-first-target/commit-and-push-our-changes.rst
+++ b/source/tutorials/creating-first-target/commit-and-push-our-changes.rst
@@ -7,7 +7,7 @@ version of the container.
 
 In this chapter, you will work on final adjustments before sending your changes to 
 the remote repository. This triggers FoundriesFactory CI to start a new build, which 
-compiles and publishes your application to `Foundries.io hub <https://hub.foundries.io/>`_.
+compiles and publishes your application to `Foundries.io hub <https://hub-ui.foundries.io/>`_.
 
 Open a new terminal on your host machine and find the container folder used in 
 the previous tutorial.
@@ -17,7 +17,7 @@ the previous tutorial.
      cd containers/
 
 Edit the ``shellhttpd/docker-compose.yml`` file and change the image back 
-to hub.foundries.io.
+to **hub.foundries.io**.
 
 .. prompt:: bash host:~$, auto
 


### PR DESCRIPTION
Simple change to hub-ui for looking at images instead of hub.foundries.io

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

There is a split in the domain of `hub.foundries.io` into `hub-ui.foundries.io` for the UI/UX and `hub-auth.foundries.io` that just does the authorization part. This change reflects that new split.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.