### PR TITLE
fix(layout): update google analytics code

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -2,6 +2,18 @@
 
 {%- block extrahead %}
 {{ super() }}
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-RQKGR35S47"></script>
+  <script>
+    if (navigator.doNotTrack === '1') {
+      function gtag() { };
+    } else {
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+    }
+
+    gtag('js', new Date());
+    gtag('config', 'G-RQKGR35S47');
+  </script>
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
The old GA code used was an old Universal Analytics and it was shared with app.foundries.io.

Universal Analytics is going to be deprecated on July 2023, and we need a dedicated tracking code.

No checks/lints have been run, since no documentation content has been changed.

Signed-off-by: Milo Casagrande <milo@foundries.io>
