### PR TITLE
fix(layout): remove google analytics

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -2,26 +2,9 @@
 
 {%- block extrahead %}
 {{ super() }}
-<script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-110020416-1']);
-  _gaq.push(['_trackPageview']);
-</script>
 {% endblock %}
 
 {% block footer %}
 {{ super() }}
-<div class="footer">This page uses <a href="https://analytics.google.com/">
-Google Analytics</a> to collect statistics. You can disable it by blocking
-the JavaScript coming from www.google-analytics.com.
-<script>
-  (function() {
-    var ga = document.createElement('script');
-    ga.src = ('https:' == document.location.protocol ?
-              'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    ga.setAttribute('async', 'true');
-    document.documentElement.firstChild.appendChild(ga);
-  })();
-</script>
 </div>
 {% endblock %}


### PR DESCRIPTION
We need to have a cookie consent element in place to be able to serve google analytics.
This is a temporary solution until we have a cookie consent element.

Signed-off-by: Milo Casagrande <milo@foundries.io>