### PR TITLE
fix(git): Added recovery path from error

### DIFF
--- a/source/getting-started/git-config/index.rst
+++ b/source/getting-started/git-config/index.rst
@@ -50,6 +50,14 @@ Run the following command to add the relevant entries to the Git configuration:
    The reason it needs to be run as ``sudo`` instead of directly as the ``root`` user is
    because it needs to have privileges to create a symlink in the same directory as where ``git`` is located.
 
+.. warning::
+   If for some reason the command fails with an error, the following manual steps can be taken to get the exact same result.
+   ``git config --global credential.https://source.foundries.io.username fio-oauth2``
+   ``git config --global credential.https://source.foundries.io.helper fio``
+
+   ``ln -s /usr/bin/fioctl /usr/bin/git-credential-fio``
+
+
 Verify that this has been successful by cloning a repository from your Factory,
 such as your ``containers.git`` repo. Replace ``<factory>`` with your
 FoundriesFactory name:


### PR DESCRIPTION
## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Added the manual steps one can take in order to make sure you are not blocked when faced with an error. Aside from that I changed the fioctl code to try and use the `uid` instead of the username.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._

Signed-off-by: Eric Bode <eric.bode@foundries.io>
