### PR TITLE
offline-update: describe fioctl token scope

### DIFF
--- a/source/user-guide/offline-update/offline-update.rst
+++ b/source/user-guide/offline-update/offline-update.rst
@@ -42,6 +42,9 @@ Use the command ``fioctl targets offline-update <target-name> <dst> --tag <tag> 
 
     Ensure that the target device is a *Production* device, see :ref:`Manufacturing Process for Device Registration <ref-factory-registration-ref>` for more details.
 
+.. note::
+    In order to download all artifacts, ``fioctl`` requires token with scopes: ``targets:read``, ``ci:read``.
+
 Performing the Offline Update
 -----------------------------
 Before doing the offline update, make the offline update content accessible on a device, e.g., attach and mount the USB drive.


### PR DESCRIPTION
fioctl requires token with proper scope in order to download offline update. This patch adds this detail to the offline-update page.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

This patch clarifies the scope of token required to download offline update

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

