### PR TITLE
rm: Add documenation for certificate rotation

### DIFF
--- a/source/reference-manual/factory/event-queues.rst
+++ b/source/reference-manual/factory/event-queues.rst
@@ -192,6 +192,17 @@ DEVICE_OTA_APPS_STATE_CHANGED
    }
  }
 
+DEVICE_PUBKEY_CHANGE
+~~~~~~~~~~~~~~~~~~~~
+::
+
+ {
+   "Uuid": <string: DEVICE_UUID>,
+   "Time": <integer: unix seconds>,
+   "NewPubKey": <string: New PEM encoded public key>,
+   "OldPubKey": <string: Old PEM encoded public key>
+ }
+
 .. _API:
    https://api.foundries.io/ota/
 

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -102,7 +102,7 @@ User Managed
 ~~~~~~~~~~~~
 
 Users may also run their own EST server.
-The EST server used by the Foundries.io backend is available at:
+The EST server used by the Foundries.io® backend is available at:
 
   https://github.com/foundriesio/estserver
 
@@ -112,12 +112,12 @@ Performing a Certificate Rotation
 ---------------------------------
 
 Certificate rotations are triggered via configuration changes.
-Fioctl includes a helper for doing this either per device or per device group with:
+Fioctl™ includes a helper for doing this either per device or per device group with:
 
  * ``fioctl device config rotate-certs <device>``
  * ``fioctl config rotate-certs --group <group>``
 
-In both cases fioctl defines a file and change handler such as::
+In both cases Fioctl defines a file and change handler such as::
 
   fio-rotate-certs - [/usr/share/fioconfig/handlers/renew-client-cert]
      | ESTSERVER=https://4a53f331-6f01-4694-8a97-af253d4d9b63.est.foundries.io:8443/.well-known/est
@@ -136,5 +136,5 @@ The ``renew-client-cert`` handler requires a few parameters:
 
  * **ESTSERVER**: The base URL to your EST resources.
  * **ROTATIONID**: This unique ID will be used as the correlation ID when the device sends update events to the device-gateway.
- * **PKEYIDS** - Devices configured to use HSMs need to know a list of slot IDs to choose from when generating the next private key. 2 IDs are required so it can swap back and forth.
+ * **PKEYIDS**: Devices configured to use HSMs need to know a list of slot IDs to choose from when generating the next private key. 2 IDs are required so it can swap back and forth.
  * **CERTIDS**: Devices configured to use HSMs need to know a list of slot IDs to choose from when storing the new client certificate. 2 IDs are required so it can swap back and forth.

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -44,8 +44,13 @@ The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process 
 
  * EST Server verifies request, creates a new certificate, and returns it to the device
 
+ * The new certificate is valid for `one year`_
+
 .. _simple re-enrollment:
    https://www.rfc-editor.org/rfc/rfc7030.html#section-4.2.2
+
+.. _one year:
+   https://github.com/foundriesio/estserver/blob/1b32b40729c60e8dfa21155dd1d31135244e56c1/service.go#L210
 
 Tracking Progress
 -----------------

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -1,0 +1,132 @@
+.. _ref-cert-rotation:
+
+Device Certificate Rotation
+===========================
+
+Factory devices communicate with the :ref:`device gateway <ref-device-gateway>` via mutual TLS where both the device and server establish trust with each other.
+A device receives an x509 client certificate during device registration that’s valid for 20 years.
+This validity period is common in IoT, but security bodies like NIST recommend changing keys like this on a yearly basis.
+Certificate rotation is the process you can use to do this.
+
+The Foundries process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport(EST).
+
+.. _RFC 7030:
+   https://www.rfc-editor.org/rfc/rfc7030.html
+
+How It Works
+------------
+
+The certificate rotation process is handled by :ref:`ref-fioconfig` on devices.
+Fioconfig carefully executes a sequence of atomic operations that can withstand unexpected power failures and reboots.
+When triggered a device will:
+
+ * Obtain a new keypair (private key and client certificate) from its configured EST server
+
+ * Inform the device gateway of this new key in order to
+
+   * Provide some 2FA guarantees - device must prove possession of both keys
+
+   * Let the backend know that configuration operations for this device should be rejected until this new key is in use
+
+ * Re-encrypts its encrypted configuration values
+
+ * Reconfigures aktualizr-lite and fioconfig to use the new keypair
+
+ * Restarts fioconfig and aktualizr-lite
+
+ * The device-gateway will see this new certificate, check that it matches the certificate from step 2, and then finally add the old certificate into a deny-list.
+
+The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process to obtain a new certificate. The process is roughly:
+
+ * Device generates a new private key and certificate signing request copying the Subject of its current certificate.
+
+ * Device sends CSR to EST server authenticating to it with its current certificate
+
+ * EST Server verifies request, creates a new certificate, and returns it to the device
+
+.. _simple re-enrollment:
+   https://www.rfc-editor.org/rfc/rfc7030.html#section-4.2.2
+
+Tracking Progress
+-----------------
+
+Fioconfig will emit update events during a certificate rotation so that operators can observe the progress of the rotation.
+For example::
+
+  $ fioctl devices updates <device>
+  ID                    TIME                  VERSION  TARGET
+  --                    ----                  -------  ------
+  certs-1669676316      2022-11-28T23:03:51Z  290      intel-corei7-64-lmp-290
+
+Update ID's prefixed with "cert-" are rotations.
+Details can be viewed with::
+
+  $ fioctl devices updates <device> certs-1669674502
+  2022-11-28T22:29:49+00:00 : CertRotationStarted(intel-corei7-64-lmp-290) -> Succeed
+  2022-11-28T22:29:50+00:00 : Generate new certificate(intel-corei7-64-lmp-290) -> Succeed
+  2022-11-28T22:29:50+00:00 : Lock device configuration on server(intel-corei7-64-lmp-290) -> Succeed
+  2022-11-28T22:29:50+00:00 : Update local configuration with new key(intel-corei7-64-lmp-290) -> Succeed
+  2022-11-28T22:29:51+00:00 : Update device specific configuration on server with new key(intel-corei7-64-lmp-290) -> Succeed
+  2022-11-28T22:29:51+00:00 : Finalize aktualizr configuration(intel-corei7-64-lmp-290) -> Succeed
+
+In addition to update events, when a new key is in place a ``DEVICE_PUBKEY_CHANGE`` event will be sent to the factory's :ref:`ref-event-queues`.
+This message plus the ``DEVICE_CONFIG_APPLIED`` should help you understand when rotations happen.
+
+Configuring a Server
+--------------------
+
+Before you can perform certificate rotations, you must ensure you have taken control of your factory's :ref:`PKI <ref-device-gateway>`.
+Specifically, you'll need access to your ``factory_ca.key`` in order to complete these steps.
+There are options to choose from.
+
+Foundries Managed
+~~~~~~~~~~~~~~~~~
+
+Running ``fioctl keys est authorize`` will allow the Foundries.io to run an EST server for you at ``<repoid>.est.foundries.io``.
+This command will sign a CSR created in the backend with your Factory's root key.
+The resulting TLS certificate will be used by the Foundries.io EST server.
+
+.. note::
+   This option requires the Foundries.io backend to have a certificate authority to sign renewal requests.
+   This "online-ca" is configured when running ``fioctl keys ca create``.
+
+User Managed
+~~~~~~~~~~~~
+
+Users may also run their own EST server.
+The EST server used by the Foundries.io backend is available at:
+
+  https://github.com/foundriesio/estserver
+
+The GitHub project includes the details for getting this server up and running.
+
+Performing a Certificate Rotation
+---------------------------------
+
+Certificate rotations are triggered via configuration changes.
+Fioctl includes a helper for doing this either per device or per device group with:
+
+ * ``fioctl device config-rotate-certs <device>``
+ * ``fioctl config rotate-certs --group <group>``
+
+In both cases fioctl defines a file and change handler like::
+
+  fio-rotate-certs - [/usr/share/fioconfig/handlers/renew-client-cert]
+     | ESTSERVER=https://4a53f331-6f01-4694-8a97-af253d4d9b63.est.foundries.io:8443/.well-known/est
+     | PKEYIDS=01,07
+     | CERTIDS=03,09
+     | ROTATIONID=certs-1669058841
+
+Certificate rotation will be executed when fioconfig processes this new file.
+If you are using a factory managed EST server, the command works out of the box.
+However, user managed EST servers will require running ``rotate-certs`` with the ``--server-name`` option to inform devices where the EST server is located.
+
+Parameters
+~~~~~~~~~~
+
+The ``renew-client-cert`` handler requires a few parameters:
+
+ * **ESTSERVER** - The base URL to your EST resources.
+ * **ROTATIONID** - This unique ID will be used as the correlation ID when the device sends update events to the device-gateway.
+ * **PKEYIDS** - Devices configured to use HSMs need to know a list of slot IDs to choose from when generating the next private key. 2 IDs are required so it can swap back and forth.
+ * **CERTIDS** - Devices configured to use HSMs need to know a list of slot IDs to choose from when storing the new client certificate. 2 IDs are required so it can swap back and forth.

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -8,7 +8,7 @@ A device receives an x509 client certificate during device registration that’s
 This validity period is common in IoT, but security bodies like NIST_ recommend changing keys like this on a yearly basis.
 Certificate rotation is the process you can use to do this.
 
-The Foundries process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport(EST).
+The Foundries process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport (EST).
 
 .. _NIST:
    https://www.nist.gov/
@@ -26,7 +26,7 @@ When triggered a device will:
 
  * Inform the device gateway of this new key in order to
 
-   * Provide some 2FA guarantees - device must prove possession of both keys
+   * Provide some 2FA guarantees—device must prove possession of both keys
 
    * Let the backend know that configuration operations for this device should be rejected until this new key is in use
 
@@ -42,7 +42,7 @@ The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process 
 
  * Device generates a new private key and certificate signing request copying the Subject of its current certificate.
 
- * Device sends Certificate Signing Request(CSR) to EST server authenticating to it with its current certificate
+ * Device sends Certificate Signing Request (CSR) to EST server authenticating to it with its current certificate
 
  * EST Server verifies request, creates a new certificate, and returns it to the device
 
@@ -124,7 +124,7 @@ In both cases fioctl defines a file and change handler like::
      | CERTIDS=03,09
      | ROTATIONID=certs-1669058841
 
-Certificate rotation will be executed when fioconfig processes this new file.
+Certificate rotation will be executed when ``fioconfig`` processes this new file.
 If you are using a factory managed EST server, the command works out of the box.
 However, user managed EST servers will require running ``rotate-certs`` with the ``--server-name`` option to inform devices where the EST server is located.
 
@@ -133,7 +133,7 @@ Parameters
 
 The ``renew-client-cert`` handler requires a few parameters:
 
- * **ESTSERVER** - The base URL to your EST resources.
- * **ROTATIONID** - This unique ID will be used as the correlation ID when the device sends update events to the device-gateway.
+ * **ESTSERVER**: The base URL to your EST resources.
+ * **ROTATIONID**: This unique ID will be used as the correlation ID when the device sends update events to the device-gateway.
  * **PKEYIDS** - Devices configured to use HSMs need to know a list of slot IDs to choose from when generating the next private key. 2 IDs are required so it can swap back and forth.
- * **CERTIDS** - Devices configured to use HSMs need to know a list of slot IDs to choose from when storing the new client certificate. 2 IDs are required so it can swap back and forth.
+ * **CERTIDS**: Devices configured to use HSMs need to know a list of slot IDs to choose from when storing the new client certificate. 2 IDs are required so it can swap back and forth.

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -4,11 +4,11 @@ Device Certificate Rotation
 ===========================
 
 Factory devices communicate with the :ref:`device gateway <ref-device-gateway>` via mutual TLS where both the device and server establish trust with each other.
-A device receives an x509 client certificate during device registration that’s valid for 20 years.
-This validity period is common in IoT, but security bodies like NIST_ recommend changing keys like this on a yearly basis.
+A device receives an x509 client certificate during device registration that is valid for 20 years.
+This validity period is common in IoT, but security bodies like NIST_ recommend changing such keys on a yearly basis.
 Certificate rotation is the process you can use to do this.
 
-The Foundries process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport (EST).
+The FoundriesFactory® process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport (EST).
 
 .. _NIST:
    https://www.nist.gov/
@@ -24,19 +24,20 @@ When triggered a device will:
 
  * Obtain a new keypair (private key and client certificate) from its configured EST server
 
- * Inform the device gateway of this new key in order to
+ * Inform the device gateway of this new key in order to:
 
    * Provide some 2FA guarantees—device must prove possession of both keys
 
-   * Let the backend know that configuration operations for this device should be rejected until this new key is in use
+   * Let the backend know that configuration operations should be rejected until the new key is in use
 
- * Re-encrypts its encrypted configuration values
+ * Re-encrypts its configuration values
 
  * Reconfigures aktualizr-lite and fioconfig to use the new keypair
 
  * Restarts fioconfig and aktualizr-lite
 
- * The device-gateway will see this new certificate, check that it matches the certificate from step 2, and then finally add the old certificate into a deny-list.
+ * The device-gateway will see this new certificate then check that it matches the certificate from step 2.
+ Finally it adds the old certificate into a deny-list.
 
 The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process to obtain a new certificate. The process is roughly:
 
@@ -89,12 +90,12 @@ There are options to choose from.
 Foundries Managed
 ~~~~~~~~~~~~~~~~~
 
-Running ``fioctl keys est authorize`` will allow the Foundries.io to run an EST server for you at ``<repoid>.est.foundries.io``.
+Running ``fioctl keys est authorize`` will allow FoundriesFactory to run an EST server for you at ``<repoid>.est.foundries.io``.
 This command will sign a CSR created in the backend with your Factory's root key.
-The resulting TLS certificate will be used by the Foundries.io EST server.
+The resulting TLS certificate will be used by the FoundriesFactory EST server.
 
 .. note::
-   This option requires the Foundries.io backend to have a certificate authority to sign renewal requests.
+   This option requires the FoundriesFactory backend to have a certificate authority to sign renewal requests.
    This "online-ca" is configured when running ``fioctl keys ca create``.
 
 User Managed
@@ -116,7 +117,7 @@ Fioctl includes a helper for doing this either per device or per device group wi
  * ``fioctl device config rotate-certs <device>``
  * ``fioctl config rotate-certs --group <group>``
 
-In both cases fioctl defines a file and change handler like::
+In both cases fioctl defines a file and change handler such as::
 
   fio-rotate-certs - [/usr/share/fioconfig/handlers/renew-client-cert]
      | ESTSERVER=https://4a53f331-6f01-4694-8a97-af253d4d9b63.est.foundries.io:8443/.well-known/est
@@ -125,7 +126,7 @@ In both cases fioctl defines a file and change handler like::
      | ROTATIONID=certs-1669058841
 
 Certificate rotation will be executed when ``fioconfig`` processes this new file.
-If you are using a factory managed EST server, the command works out of the box.
+If you are using a Factory managed EST server, the command works out of the box.
 However, user managed EST servers will require running ``rotate-certs`` with the ``--server-name`` option to inform devices where the EST server is located.
 
 Parameters

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -37,7 +37,7 @@ When triggered a device will:
  * Restarts fioconfig and aktualizr-lite
 
  * The device-gateway will see this new certificate then check that it matches the certificate from step 2.
- Finally it adds the old certificate into a deny-list.
+    Finally it adds the old certificate into a deny-list.
 
 The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process to obtain a new certificate. The process is roughly:
 

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -106,7 +106,7 @@ Performing a Certificate Rotation
 Certificate rotations are triggered via configuration changes.
 Fioctl includes a helper for doing this either per device or per device group with:
 
- * ``fioctl device config-rotate-certs <device>``
+ * ``fioctl device config rotate-certs <device>``
  * ``fioctl config rotate-certs --group <group>``
 
 In both cases fioctl defines a file and change handler like::

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -87,8 +87,8 @@ Before you can perform certificate rotations, you must ensure you have taken con
 Specifically, you'll need access to your ``factory_ca.key`` in order to complete these steps.
 There are options to choose from.
 
-Foundries Managed
-~~~~~~~~~~~~~~~~~
+FoundriesFactory Managed
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Running ``fioctl keys est authorize`` will allow FoundriesFactory to run an EST server for you at ``<repoid>.est.foundries.io``.
 This command will sign a CSR created in the backend with your Factory's root key.
@@ -102,7 +102,7 @@ User Managed
 ~~~~~~~~~~~~
 
 Users may also run their own EST server.
-The EST server used by the Foundries.io® backend is available at:
+The EST server used by the Foundries.io™ backend is available at:
 
   https://github.com/foundriesio/estserver
 

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -5,11 +5,13 @@ Device Certificate Rotation
 
 Factory devices communicate with the :ref:`device gateway <ref-device-gateway>` via mutual TLS where both the device and server establish trust with each other.
 A device receives an x509 client certificate during device registration that’s valid for 20 years.
-This validity period is common in IoT, but security bodies like NIST recommend changing keys like this on a yearly basis.
+This validity period is common in IoT, but security bodies like NIST_ recommend changing keys like this on a yearly basis.
 Certificate rotation is the process you can use to do this.
 
 The Foundries process for rotating device certificates is based on the industry standard `RFC 7030`_ Enrollment over Secure Transport(EST).
 
+.. _NIST:
+   https://www.nist.gov/
 .. _RFC 7030:
    https://www.rfc-editor.org/rfc/rfc7030.html
 
@@ -40,7 +42,7 @@ The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process 
 
  * Device generates a new private key and certificate signing request copying the Subject of its current certificate.
 
- * Device sends CSR to EST server authenticating to it with its current certificate
+ * Device sends Certificate Signing Request(CSR) to EST server authenticating to it with its current certificate
 
  * EST Server verifies request, creates a new certificate, and returns it to the device
 

--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -22,22 +22,22 @@ The certificate rotation process is handled by :ref:`ref-fioconfig` on devices.
 Fioconfig carefully executes a sequence of atomic operations that can withstand unexpected power failures and reboots.
 When triggered a device will:
 
- * Obtain a new keypair (private key and client certificate) from its configured EST server
+ #. Obtain a new keypair (private key and client certificate) from its configured EST server
 
- * Inform the device gateway of this new key in order to:
+ #. Inform the device gateway of this new key in order to:
 
-   * Provide some 2FA guarantees—device must prove possession of both keys
+    * Provide some 2FA guarantees—device must prove possession of both keys
 
-   * Let the backend know that configuration operations should be rejected until the new key is in use
+    * Let the backend know that configuration operations should be rejected until the new key is in use
 
- * Re-encrypts its configuration values
+ #. Re-encrypts its configuration values
 
- * Reconfigures aktualizr-lite and fioconfig to use the new keypair
+ #. Reconfigures aktualizr-lite and fioconfig to use the new keypair
 
- * Restarts fioconfig and aktualizr-lite
+ #. Restarts fioconfig and aktualizr-lite
 
- * The device-gateway will see this new certificate then check that it matches the certificate from step 2.
-    Finally it adds the old certificate into a deny-list.
+ #. The device-gateway will see this new certificate then check that it matches the certificate from step 2.
+ #. Finally it adds the old certificate into a deny-list.
 
 The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process to obtain a new certificate. The process is roughly:
 

--- a/source/reference-manual/security/ota-security.rst
+++ b/source/reference-manual/security/ota-security.rst
@@ -10,5 +10,6 @@ Over the Air Updates
 
    offline-keys
    device-gateway
+   cert-rotation
    factory-registration-ref
    device-network-access


### PR DESCRIPTION
Signed-off-by: Andy Doan <andy@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

The next LmP release will include the ability for users to rotate device client certificates. This new document outlines the process.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
