### PR TITLE
Add basic linter action for PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: reviewdog
+on:
+  pull_request:
+    branches:
+    - main
+jobs:
+  vale:
+    name: runner / vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+         reporter: github-pr-check
+         fail_on_error: false
+        env:
+          # Required, set by GitHub actions automatically:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Adding the vale-action/reviewdog github action to run for PRs open against main. Note that it will fail on errors, more work will be needed to get suggestions and warnings posted automatically as review comments, and it is still recommended that vale is run locally against changes before opening a PR.

This was tested on a fork, so there may need to be changes (such as to the TOKEN) before it works properly under the Foundriesio account.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
