### PR TITLE
add note about oe_builtin set under lmp configuration

### DIFF
--- a/source/reference-manual/linux/preloaded-images.rst
+++ b/source/reference-manual/linux/preloaded-images.rst
@@ -31,7 +31,6 @@ The easiest way to configure this is by updating a Factory's
          enabled: true
          app_type: <restorable|compose>
          shortlist: "money-making-app,debug-tools"
-         oe_builtin: <true|false>
 
 Where:
 
@@ -40,12 +39,23 @@ Where:
 - ``app_type`` - *Optional*: Defines a type of Apps to preload.
   If an option is not defined or set to an empty value, the ``app_type``  preload will depend on the LmP version. If the LmP version is equal to or higher than **v85**, then `restorable` type is preloaded, otherwise `compose` type.
   See :ref:`ug-restorable-apps` for more details on Restorable Apps.
-- ``oe_builtin`` - *Optional*: Defines a way to accomplish preloading Apps. If the option is not defined or set to `false` (by default),
-  then Apps are preloaded by the `assemble` run of a LmP CI build. Otherwise, Apps are preloaded during an OE build CI run.
-  In this case, rootfs as well as a system image produced by the run includes preloaded Apps.
-  Only `Restorable` type of Apps (default) are supported by the OE builtin preloader.
-  This option does not work with some of the advanced tagging cases,
-  e.g. in the case of multiple container builds using the same platform (see :ref:`ref-advanced-tagging` for more details).
+
+.. note::
+
+   There is also one additional parameter ``oe_builtin: <true|false>``:
+
+   - ``oe_builtin`` - Defines a way to accomplish preloading Apps. If the option is not defined or set to `false` (by default), then Apps are preloaded by the `assemble` run of a LmP CI build. Otherwise, Apps are preloaded during an OE build CI run. In this case, rootfs as well as a system image produced by the run includes preloaded Apps. Only `Restorable` type of Apps (default) are supported by the OE builtin preloader. This option does not work with some of the advanced tagging cases, e.g. in the case of multiple container builds using the same platform (see :ref:`ref-advanced-tagging` for more details).
+
+   When setting this option, apps are preloaded during an OE/platform build CI run, so container builds will not provide an image with preloaded apps as they do not rely on OE build steps. So for this setting, the preload configuration should be under ``lmp:``:
+
+   .. prompt:: text
+
+     lmp:
+       preloaded_images:
+         enabled: true
+         app_type: <restorable|compose>
+         shortlist: "shellhttpd"
+         oe_builtin: true
 
 For simple workflows, this may suffice. Because ``lmp`` configuration inherits from 
 ``containers``, it will cause every **Target** built in the Factory to include and 

--- a/source/user-guide/container-preloading/container-preloading.rst
+++ b/source/user-guide/container-preloading/container-preloading.rst
@@ -52,19 +52,29 @@ Edit the ``factory-config.yml`` file and add the configuration below:
          enabled: true
          app_type: <restorable|compose>
          shortlist: "shellhttpd"
-         oe_builtin: <true|false>
 
 - ``enabled`` -  Whether to produce an archive containing docker images as part of a container build trigger.
 - ``shortlist`` - Defines the list of apps to preload. All Target's apps are preloaded if it is not specified or its value is empty. Here, it is set to preload the ``shellhttpd`` app.
 - ``app_type`` - Defines a type of Apps to preload.
   If an option is not defined or set to an empty value, the ``app_type``  preload will depend on the LmP version. If the LmP version is equal to or higher than **v85**, then `restorable` type is preloaded, otherwise `compose` type.
   See :ref:`ug-restorable-apps` for more details on Restorable Apps.
-- ``oe_builtin`` - Defines a way to accomplish preloading Apps. If the option is not defined or set to `false` (by default),
-  then Apps are preloaded by the `assemble` run of a LmP CI build. Otherwise, Apps are preloaded during an OE build CI run.
-  In this case, rootfs as well as a system image produced by the run includes preloaded Apps.
-  Only `Restorable` type of Apps (default) are supported by the OE builtin preloader.
-  This option does not work with some of the advanced tagging cases,
-  e.g. in the case of multiple container builds using the same platform (see :ref:`ref-advanced-tagging` for more details).
+
+.. note::
+
+   There is also one additional parameter ``oe_builtin: <true|false>``:
+
+   - ``oe_builtin`` - Defines a way to accomplish preloading Apps. If the option is not defined or set to `false` (by default), then Apps are preloaded by the `assemble` run of a LmP CI build. Otherwise, Apps are preloaded during an OE build CI run. In this case, rootfs as well as a system image produced by the run includes preloaded Apps. Only `Restorable` type of Apps (default) are supported by the OE builtin preloader. This option does not work with some of the advanced tagging cases, e.g. in the case of multiple container builds using the same platform (see :ref:`ref-advanced-tagging` for more details).
+
+   When setting this option, apps are preloaded during an OE/platform build CI run, so container builds will not provide an image with preloaded apps as they do not rely on OE build steps. So for this setting, the preload configuration should be under ``lmp:``:
+
+   .. prompt:: text
+
+     lmp:
+       preloaded_images:
+         enabled: true
+         app_type: <restorable|compose>
+         shortlist: "shellhttpd"
+         oe_builtin: true
 
 
 Add the ``factory-config.yml`` file, commit and push:


### PR DESCRIPTION
oe_builtin often confuses our customers as the doc is misleading about this step and this should be set under lmp configuration.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

## Readiness

* [ ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
