### PR TITLE
fix: cookie notice

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -31,7 +31,7 @@
     const cookieConsent = window.CookieConsent({
       acceptAllButton: false,
       labels: {
-        description: `<p>This site makes use of third-party cookies as explained in our <a href="/company/cookie-policy/">Cookie Policy</a>, <a href="/company/privacy/">Privacy Policy</a> and <a href="/company/terms/">Terms and Conditions</a>.</p>`
+        description: `<p>This site makes use of third-party cookies as explained in our <a href="https://foundries.io/company/cookie-policy/">Cookie Policy</a>, <a href="https://foundries.io/company/privacy/">Privacy Policy</a> and <a href="https://foundries.io/company/terms/">Terms and Conditions</a>.</p>`
       },
       cookies: [
         {

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -45,7 +45,7 @@
           id: 'analytics',
           label: 'Analytics (non-essential)',
           required: false,
-          checked: false,
+          checked: true,
           description: 'Cookies needed to understand how users interact with Foundries.io websites and resources.',
         }
       ],


### PR DESCRIPTION
## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Make the analytics cookie selection on by default (as per marketing), and fix the policy links to point to foundries.io website.
