### PR TITLE
Linux fragments

### DIFF
--- a/source/porting-guide/pg-spl-kernel.rst
+++ b/source/porting-guide/pg-spl-kernel.rst
@@ -26,7 +26,7 @@ dtb, so LmP relies on ``lmp-device-tree`` which is based on the Yocto Project
 device-tree class.
 
 For the kernel configuration, LmP makes use of the kernel fragments,
-using the Yocto Project mechanism also present on linux-yocto. This is
+using the Yocto Project mechanism also present on ``linux-yocto``. This is
 different from the also common “in-tree” configuration, which uses the
 file ``defconfig`` to configure the kernel.
 
@@ -34,7 +34,7 @@ Creating the Kernel fragments
 -----------------------------
 
 The kernel configuration files are part of the ``lmp-kernel-cache``
-repository which have a helpful README file, and is also described in
+repository which have a helpful ``README`` file, and is also described in
 the :ref:`ref-linux-fragments`.
 
 In short, there are several well known kernel features defined in
@@ -42,7 +42,7 @@ fragment files (such as the bluetooth feature) alongside other
 configurations. The ``bsp`` directory is where fragments related
 to the BSP are stored.
 
-The goal is to create a .bbappend to include the fragments which define
+The goal is to create a ``.bbappend`` to include the fragments which define
 the target machine. The set of files should look like the following:
 
 .. prompt:: text
@@ -59,7 +59,7 @@ the target machine. The set of files should look like the following:
     └── linux-<name>_%.bbappend
 
 Where ``<name>`` is the kernel name for the particular kernel recipe being
-used. The patch files are potential patches applied by the .bbappend
+used. The patch files are potential patches applied by the ``.bbappend``
 file on top of the kernel source code and ``<machine>`` is the machine name.
 The ``<sub-group>`` is a BSP subgroup, following the lmp-kernel-cache
 directory organization. For example, ``imx`` or ``raspberrypi``, depending on
@@ -97,10 +97,10 @@ code is by creating a recipe file for this module under
     recipes-kernel/kernel-modules/
     └── <module>
         ├── <module>
-        │   ├── COPYING
-        │   ├── Makefile
-        │   ├── <module>.c
-        │   └── <module>.h
+        │   ├── COPYING
+        │   ├── Makefile
+        │   ├── <module>.c
+        │   └── <module>.h
         └── <module>_<pv>.bb
 
 Where ``<module>_<pv>.bb`` is:

--- a/source/porting-guide/pg-spl-kernel.rst
+++ b/source/porting-guide/pg-spl-kernel.rst
@@ -20,7 +20,7 @@ meta-subscriber-overrides so the build generates the output ``.dtb`` file.
     │   └── <board>.dts
     └── lmp-device-tree.bbappend
 
-The strategy of using the dts file separate from the Linux Kernel
+The strategy of using the dts file separate from the Linux® Kernel
 source helps to avoid forking the kernel when including any new
 dtb, so LmP relies on ``lmp-device-tree`` which is based on the Yocto Project
 device-tree class.

--- a/source/porting-guide/pg-spl-kernel.rst
+++ b/source/porting-guide/pg-spl-kernel.rst
@@ -30,8 +30,10 @@ using the Yocto Project mechanism also present on ``linux-yocto``. This is
 different from the also common “in-tree” configuration, which uses the
 file ``defconfig`` to configure the kernel.
 
-Creating the Kernel fragments
------------------------------
+.. _ref-pg-how-to-configure-linux:
+
+How To Configure the Linux Kernel
+---------------------------------
 
 The kernel configuration files are part of the ``lmp-kernel-cache``
 repository which have a helpful ``README`` file, and is also described in

--- a/source/reference-manual/linux/linux-kernel.rst
+++ b/source/reference-manual/linux/linux-kernel.rst
@@ -29,6 +29,14 @@ repository, so the same development workflow and documentation applies.
 See the `Yocto Project Linux Kernel Development Manual`_ for more information
 on how to work and manage the kernel metadata and configuration fragments.
 
+The Porting Guide includes the section :ref:`ref-pg-how-to-configure-linux` on
+on how to add a custom Linux Kernel configuration which can be used to add:
+
+* the complete machine configuration.
+
+* fragments: a set of ``CONFIG_`` variables working to change
+  a default machine configuration.
+
 .. _github.com/foundriesio/linux: https://github.com/foundriesio/linux
 .. _github.com/foundriesio/lmp-kernel-cache: https://github.com/foundriesio/lmp-kernel-cache
 .. _Yocto Project Linux Kernel Development Manual: https://docs.yoctoproject.org/4.0.6/kernel-dev/advanced.html

--- a/source/reference-manual/linux/linux-kernel.rst
+++ b/source/reference-manual/linux/linux-kernel.rst
@@ -3,7 +3,7 @@
 Linux Kernel
 ============
 
-A common and unified Linux Kernel source tree is provided and used by
+A common and unified Linux® Kernel source tree is provided and used by
 the Linux microPlatform. The latest continuous release is available
 at `github.com/foundriesio/linux`_.
 
@@ -96,12 +96,12 @@ Set the ``PREFERRED_PROVIDER_virtual/kernel`` to ``linux-lmp-dev`` in
 
 Now just build any of the supported Linux microPlatform images.
 
-Specifying Linux git tree, branch and commit revision
+Specifying Linux Git Tree, Branch and Commit Revision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following variables can be also set in
 ``meta-subscriber-overrides/conf/machine/include/lmp-factory-custom.inc``
-in order to build ``linux-lmp-dev`` using a specific linux tree, branch or
+in order to build ``linux-lmp-dev`` using a specific Linux tree, branch or
 commit revision::
 
     KERNEL_REPO = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git" # Kernel git repository

--- a/source/reference-manual/linux/linux-kernel.rst
+++ b/source/reference-manual/linux/linux-kernel.rst
@@ -31,7 +31,7 @@ on how to work and manage the kernel metadata and configuration fragments.
 
 .. _github.com/foundriesio/linux: https://github.com/foundriesio/linux
 .. _github.com/foundriesio/lmp-kernel-cache: https://github.com/foundriesio/lmp-kernel-cache
-.. _Yocto Project Linux Kernel Development Manual: https://www.yoctoproject.org/docs/2.5/kernel-dev/kernel-dev.html#kernel-dev-advanced
+.. _Yocto Project Linux Kernel Development Manual: https://docs.yoctoproject.org/4.0.6/kernel-dev/advanced.html
 
 Linux microPlatform with Real-Time Linux Kernel
 -----------------------------------------------


### PR DESCRIPTION
## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

There are two different sections regarding "linux fragments," but only one of them shows the technical instructions on how to configure the kernel, so add the cross-reference.

Another important change is on the title, as for a lot of readers, I would expect they don't know what the term "Linux fragment" means, so I suggest another title.

While on that, fix some other minor stuff.
