### PR TITLE
Fix broken link to imx u-boot documentation

### DIFF
--- a/source/reference-manual/security/imx-generic-custom-keys.rst
+++ b/source/reference-manual/security/imx-generic-custom-keys.rst
@@ -101,4 +101,4 @@ close the board, respectively.
   after understanding its critical implications.
 
 .. _i.MX Secure Boot on HABv4 Supported Devices: https://www.nxp.com/webapp/Download?colCode=AN4581&location=null
-.. _Generating a fast authentication PKI tree: https://source.codeaurora.org/external/imx/uboot-imx/tree/doc/imx/habv4/introduction_habv4.txt?h=imx_v2020.04_5.4.70_2.3.0#n191
+.. _Generating a fast authentication PKI tree: https://github.com/nxp-imx/uboot-imx/blob/lf_v2022.04/doc/imx/habv4/introduction_habv4.txt#L193


### PR DESCRIPTION
The link was changed as of 2023-03-31, with the source documentation linked to now being hosted on GitHub. The link was updated to point to the new location.

QA steps: ran linkcheck and verified the link is functional.

No issue to link, as this is a minor fix.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
