### PR TITLE
Update and clean UG device-gateway-pki

### DIFF
--- a/source/user-guide/device-gateway-pki/device-gateway-pki.rst
+++ b/source/user-guide/device-gateway-pki/device-gateway-pki.rst
@@ -3,22 +3,25 @@
 Details Of Device Gateway PKI Settings
 ======================================
 
-The :ref:`Factory PKI <ref-device-gateway>` reference manual describes core concepts of Device Gateway PKI and
-how it can be configured by using the ``fioctl keys ca`` command.
-The following describes low-level details that are happening behind the scenes during running that ``fioctl`` command.
-Also, it provides an instruction to create, sign, and use an *offline* (aka *local*) device certificate.
+This guide covers Public Key Infrastructure (PKI) Settings.
+In particular, the low-level details of what happens behind the scenes when running the ``fioctl keys ca`` commands.
+It also provides instructions to create, sign, and use an *offline* (aka *local*) device certificate.
 
-Under The Hood
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-The PKI for Device Gateway and Factory Devices is highly important in terms of secure communication between them.
-Thus, it's important for users to understand what exactly the given command does underneath.
+The :ref:`Factory PKI <ref-device-gateway>` reference manual describes core concepts of Device Gateway PKI and how it can be configured by using the ``fioctl keys ca``.
 
-Before a user setups the PKI, their Devices and Device Gateway talk to each other by utilizing so-called "shared PKI",
-this is a default PKI that the Foundries service sets up as part of new Factory provisioning.
-The ``fioctl`` command communicates with ``https://api.foundries.io/ota/factories/$FACTORY/certs/``
-endpoint to create and update Factory specific PKI keys and certificates. As long as Factory uses the "shared PKI"
-the endpoint returns and empty response, meaning that no Factory PKI is set.
-::
+.. seealso::
+   Documentation on using :ref:`Fioctl® <ug-fioctl>`
+
+Under the Hood
+~~~~~~~~~~~~~~
+
+The PKI for Device Gateway and Factory Devices is vital for the secure communication between them.
+It is important to understand exactly what the given command does.
+
+Before a user sets up the PKI, their Devices and Device Gateway talk to each other by utilizing a so-called "shared PKI".
+This is the default PKI that FoundriesFactory® sets up as part of new Factory provisioning.
+The ``fioctl`` command communicates with the end point ``https://api.foundries.io/ota/factories/$FACTORY/certs/`` to create and update Factory specific PKI keys and certificates.
+As long as the Factory uses the "shared PKI", the endpoint returns an empty response, as no Factory PKI is set::
 
     curl -s -H "OSF-TOKEN: $TOKEN" https://api.foundries.io/ota/factories/${FACTORY}/certs/ | jq
     {
@@ -32,93 +35,82 @@ the endpoint returns and empty response, meaning that no Factory PKI is set.
 * ``tls-crt`` is a Device Gateway certificate, also referred as :ref:`a server TLS certificate <tls-crt>`
 
 
-The first step that the ``fioctl`` command does is sending a post request to the PKI endpoint.
-In the following example a response is redirected to a json file so its content can be used later.
-
-::
+The first step that the ``fioctl`` command does is send a post request to the PKI endpoint.
+In the following example, a response is redirected to a json file so its content can be used later.::
 
     curl -s -X POST -H "Content-Type: application/json" -H "OSF-TOKEN: $TOKEN" "https://api.foundries.io/ota/factories/${FACTORY}/certs/" | jq . > factory_certs.json
 
 The endpoint handler does the following:
 
-1. Generates a private key and corresponding CSR (Certificate Signing Request) for Device Gateway (tls-crt);
+1. Generates a private key and corresponding Certificate Signing Request (CSR) for Device Gateway (tls-crt);
 2. Generates a private key and corresponding CSR for Online Device CA (online-ca);
-3. Returns a json formatted response to a caller, the response includes the following:
+3. Returns a json formatted response to a caller, the response includes:
 
    a. ``tls-csr`` - CSR for Device Gateway certificate
    b. ``ca-csr`` - CSR for Online Device CA certificate
-   c. ``create_ca`` - a script that can be used for root CA creation, i.e. a private key and corresponding self-signed certificate.
-   d. ``create_device_ca`` - a script that can be used for "local-ca"/"offline-ca" creation, i.e. a private key, corresponding certificate signed by the root CA.
+   c. ``create_ca`` - a script that can be used for root CA creation, i.e. a private key and corresponding self-signed certificate
+   d. ``create_device_ca`` - a script that can be used for "local-ca"/"offline-ca" creation, i.e. a private key, corresponding certificate signed by the root CA
    e. ``sign_tls_csr`` - a script that signs received ``tls-csr`` by the root CA
-   f. ``sign_ca_csr`` - a script that signs received ``ca-csr`` ("online-ca") by the root CA
+   f. ``sign_ca_csr`` - a script that signs received ``ca-csr`` ("online-ca") by the root CA.
 
-A user can extract any of the aforementioned fields by utilizing ``jq`` utility. For example:
-
-::
+A user can extract any of the aforementioned fields by utilizing the ``jq`` utility: ::
 
     cat factory_certs.json | jq -r .create_ca
 
-Once the ``fioctl`` command receives a response it makes use of the above mentioned scripts included in a response.
-Specifically:
+Once the ``fioctl`` command receives a response, it makes use of the above scripts included in a response.
+Specifically, it:
 
 1. Invokes the ``create_ca`` script to generate Root CA key (``factory_ca.key``) and Root CA certificate (``factory_ca.pem``);
 2. Signs the ``tls-csr`` by invoking the ``sign_tls_csr`` script, the resultant certificate is stored in ``tls-crt``;
 3. Signs the ``ca-csr`` by invoking the ``sign_ca_csr`` script, the resultant certificate is stored in ``online-crt``;
 4. Creates a local/offline Device CA by using ``create_device_ca``, the resultant private key and certificate are stored in ``local-ca.key`` and ``local-ca.pem`` correspondingly;
 
-After that, the ``fioctl`` command uploads the generated artifacts to the backend by issuing a PATCH request to the endpoint.
-Specifically, the following files are uploaded:
+Then the ``fioctl`` command uploads the generated artifacts to the backend by issuing a ``PATCH`` request to the endpoint.
+The following files are uploaded:
 
 1. ``tls-crt`` - the result of ``tls-csr`` signing;
 2. ``online-crt`` and ``local-ca.pem`` bundled together into the ``ca-crt`` field of the PATCH request;
 3. ``factory_ca.pem`` - root CA certificate created by running ``create_ca`` transferred via ``root-crt`` fields of the PATCH request.
 
-It should be pointed out that the factory root of trust can be set once.
-Thus, the given command ``fioctl keys ca create`` performs work only at the first run, subsequent command calls will fail.
-Device CA bundle (``ca-crt``) can be updated many times, specifically a user may add/remove local/offline CA certs to/from the bundle,
-``fioctl keys ca update`` command is intended for it.
+.. warning::
+   The factory root of trust can be set once—contact customer support if you need to have the value reset.
+   Thus, the given command ``fioctl keys ca create`` works only for the first run, subsequent command calls will fail.
+   However Device CA bundle (``ca-crt``) can be updated many times;
+   a user may add or remove local/offline CA certs to and from the bundle with ``fioctl keys ca update``.
 
-Device key and certificate
+Device Key and Certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 Once the PKI is setup, your Factory Device Gateway is ready to communicate via mTLS with Factory devices.
-The devices must have a private key and a x509 certificate to setup mTLS session with Device Gateway
-as well as the Root CA certificate to verify Device Gateway certificate during mTLS handshake.
+The devices must have a private key and a x509 certificate to setup mTLS session with Device Gateway.
+It also needs the Root CA certificate to verify Device Gateway certificate during mTLS handshake.
 
-As explained above the ``fioctl`` command generates two types of Device CA, online and local/offline CAs.
+As explained above, the ``fioctl`` command generates two types of Device CA, online and local/offline CAs.
 Both of these CAs can be used to sign Device CSR.
 
-Online Device certificate
+Online Device Certificate
 *************************
 In the case of online CA, a private key is owned by the backend. Hence, only the backend can sign a Device CSR with the online CA.
-The utility called ``lmp-device-register`` can be used for this purpose,
-and this is the default device registration mechanism. The tool generates a device private key,
-creates corresponding device CSR and makes a request to the backend to sign it with the online CA.
+The utility called ``lmp-device-register`` can be used for this purpose, and is the default device registration mechanism.
+The tool generates a device private key, creates a corresponding device CSR, and makes a request to the backend to sign it with the online CA.
 As a response, the backend returns a signed device certificate as well as a default configuration for the device (aka ``sota.toml``).
 More details on ``lmp-device-register`` usage can be found in the :ref:`getting started guide <gs-register>`.
 
-Local/Offline Device certificate
+Local/Offline Device Certificate
 ********************************
 
-We advise users to use the Factory registration `reference implementation`_ as a mechanism for
-offline device key and certificate generation as well as device registration.
+We advise using the Factory registration `reference implementation`_ as a mechanism for offline device key and certificate generation as well as device registration.
 The following is a guide on the manual creation of Local/Offline Device keys and certificates.
 This can be useful for understanding low-level details of the overall process.
 
-
-Create a directory for offline device key and certificate.
-::
+Create a directory for offline device key and certificate::
 
     mkdir -p devices/offline-device
 
-
-Generate a private key
-::
+Generate a private key::
 
     openssl ecparam -genkey -name prime256v1 -out devices/offline-device/pkey.pem
 
-
-Set offline Device certificate config
-::
+Set offline Device certificate config::
 
    cat > devices/offline-device/device-cert.conf <<EOF
    [req]
@@ -132,34 +124,26 @@ Set offline Device certificate config
    organizationalUnitName="${FACTORY}"
    EOF
 
-Make sure to replace <device-UUID> and ${FACTORY} with your values.
+Make sure to replace ``<device-UUID>`` and ``${FACTORY}`` with your values.
 
-Set offline Device certificate extensions
-::
+Set offline Device certificate extensions::
 
    cat > devices/offline-device/device-cert.ext <<EOF
    keyUsage=critical,digitalSignature,keyAgreement
    extendedKeyUsage=critical,clientAuth
    EOF
 
-Generate CSR
-
-::
+Generate CSR::
 
     openssl req -new -config devices/offline-device/device-cert.conf -key devices/offline-device/pkey.pem -out devices/offline-device/device-cert.csr
 
-Sign CSR and produce offline Device certificate
-
-::
+Sign CSR and produce offline Device certificate::
 
     openssl x509 -req -in devices/offline-device/device-cert.csr -CAcreateserial -extfile devices/offline-device/device-cert.ext -CAkey local-ca.key -CA local-ca.pem -sha256 -out devices/offline-device/client.pem
 
-
 Check the generate offline Device key and certificate.
 Before doing that you need to find out hostname of your Factory Device Gateway,
-it can be extracted from the Device Gateway certificate (``tls-crt``)
-
-::
+it can be extracted from the Device Gateway certificate (``tls-crt``)::
 
    openssl x509 -noout -in tls-crt -ext subjectAltName
 


### PR DESCRIPTION
The user guide page on device gateway pki was updated to match style guidelines. Minor grammar and word choice changes aimed at increasing readability. A mention of the factory root of trust setting only being able to be set once was made into a warning admonition.

QA steps: Ran linkcheck and checked rendered html output. Ran linter.

No related issue.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Added warning admonition about setting root of trust only once, and general cleanup. 

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

We may want to verify that all the information is still accurate and up to date at this time. 
