### PR TITLE
Move mirror-action runs-on to 20.04

### DIFF
--- a/source/user-guide/mirror-action/mirror-action.rst
+++ b/source/user-guide/mirror-action/mirror-action.rst
@@ -171,7 +171,7 @@ Finally, create the file ``mirror.yml`` and make sure you update the ``<FACTORY-
       
       jobs:
         to_foundries:
-          runs-on: ubuntu-18.04
+          runs-on: ubuntu-20.04
           steps:
             - uses: actions/checkout@v2
               with:


### PR DESCRIPTION
It has been reported that github no longer does runs-on for 18.04

## Readiness

* [x ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
