### PR TITLE
reference-manual: linux: improve factory reset docs

### DIFF
--- a/source/reference-manual/linux/factory-device-reset.rst
+++ b/source/reference-manual/linux/factory-device-reset.rst
@@ -27,6 +27,7 @@ Partial factory reset
 ---------------------
 
 There are currently two options in partial reset.
+The main difference with full reset is that the device remains connected to the FoundriesFactory®.
 
 Keep SOTA
 ~~~~~~~~~
@@ -46,3 +47,8 @@ Contents of ``/var/`` are partially removed.
 ``/var/sota/`` contents are kept to allow aktualizr-lite and
 compose-apps to be preserved.
 ``/var/lib/`` is preserved as the docker objects are stored there.
+
+RPMB
+~~~~
+
+Currently ``RPMB`` is not cleared in either reset procedures.


### PR DESCRIPTION
Add main distinction between full and partial factory reset. Add clarification that at this point in time RPMB is not touched during factory reset.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Improves the documentation for the factory reset.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
