### PR TITLE
factory-keys.rst: improve key explanations

### DIFF
--- a/source/reference-manual/security/factory-keys.rst
+++ b/source/reference-manual/security/factory-keys.rst
@@ -24,16 +24,19 @@ When a FoundriesFactory is created, by default two set of keys are created under
 
 A pair is composed by a certificate (``*.crt``) and a key (``*.key``) file.
 
-The **dev** pair is a generic RSA 2048 key pair and is not in use.
+The name of the key indicates by which component the **public** part of the key is used.
 
-The **opteedev** pair is a RSA 2048 key pair used for OP-TEE. This is used by
-configuring the variable ``OPTEE_TA_SIGN_KEY``.
+The **dev** pair is a generic ``RSA`` 2048 key pair and is not in use.
 
-The **ubootdev** pair is a RSA 2048 key pair used for U-Boot proper. This is used by
-configuring the variable ``UBOOT_SPL_SIGN_KEYNAME``.
+The **opteedev** pair is a ``RSA`` 2048 key pair by ``OP-TEE`` in order to validate trusted
+applications run by ``OP-TEE``. This is used by configuring the variable ``OPTEE_TA_SIGN_KEY``.
 
-The **spldev** key pair is a RSA 2048 key pair used for U-Boot SPL. This is
-used by configuring the variable ``UBOOT_SPL_SIGN_KEYNAME``.
+The **ubootdev** pair is a ``RSA`` 2048 key pair by U-Boot proper in order to validate the
+Linux® Kernel. This is used by configuring the variable ``UBOOT_SPL_SIGN_KEYNAME``.
+
+The **spldev** key pair is a ``RSA`` 2048 key pair used by U-Boot ``SPL`` in order to validate
+``FIT`` image containing U-Boot and ``OP-TEE``.
+This is used by configuring the variable ``UBOOT_SPL_SIGN_KEYNAME``.
 
 The file ``x509.genkey`` is a configuration file used for creating
 ``privkey_modsign.pem`` and ``x509_modsign.crt`` which is a RSA 2048 pair in PEM


### PR DESCRIPTION
Remove ambiguity in the documentation explaining the different keys. Adding explanation that the naming indicated where the public part is used. Also extending the documentation to indicate which part is being validated by the key.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [X] Run spelling and grammar check, preferably with linter.
* [X] Avoid changing any header associated with a link/reference.
* [X] Step through instructions (or ask someone to do so).
* [X] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [X] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [X] View HTML in a browser to check rendering.
* [X] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ X follow best practices for commits.
  * [X] Descriptive title written in the imperative.
  * [X] Include brief overview of QA steps taken.
  * [X] Mention any related issues numbers.
  * [X] End message with sign off/DCO line (`-s, --signoff`).
  * [X] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [X] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
