### PR TITLE
offline-update: Synchronize the fioctl targets offline-update adding …

### DIFF
--- a/source/user-guide/offline-update/offline-update.rst
+++ b/source/user-guide/offline-update/offline-update.rst
@@ -30,12 +30,13 @@ The offline update content consists of:
 2. `OSTree`_ repo containing a device's rootfs;
 3. :ref:`Compose Apps <ref-compose-apps>`.
 
-Use the command ``fioctl targets offline-update <target-name> <dst> --tag <tag> [--prod]`` to download the update content.
+Use the command ``fioctl targets offline-update <target-name> <dst> --tag <tag> [--prod] [--expires-in-days <days>]`` to download the update content.
 
 * ``<target-name>`` - denotes the Target to update a device to
 * ``<dst>`` - defines a path to download the update content to
 * ``<tag>`` - specifies the Target tag and the tag that the device is on
 * ``--prod`` - indicates that this is an update for a production device and ``<target-name>`` refers to *Production Target* (see the note below)
+* ``<days>`` - Offline artifact validity period in days
 
 .. note::
     Use ``fioctl waves init/complete`` commands to generate :ref:`Production Targets <ref-production-targets>`.


### PR DESCRIPTION
Add the --expire-in-days option to fioctl targets offline-update

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_
Based on customer comment on FS-1645, this is a small fix to synchronize the `fioctl targets offline-update` with https://docs.foundries.io/latest/reference-manual/factory/fioctl/fioctl_targets_offline-update.html

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
