### PR TITLE
Add Reference Manual summary page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -58,7 +58,8 @@ OE/Yocto Project, the Linux microPlatform™ and Docker®.
    :maxdepth: 1
    :caption: Reference Manual
    :name: sec-manual
-
+  
+   reference-manual/index
    reference-manual/docker/docker
    reference-manual/boards/boards
    reference-manual/qemu/qemu

--- a/source/reference-manual/index.rst
+++ b/source/reference-manual/index.rst
@@ -1,0 +1,22 @@
+.. _ref-manual:
+
+Overview
+========
+
+The FoundriesFactory® Reference Manual provides technical details, command options, and API calls, as well as instructions for some advanced use cases.
+See the User Guide or Tutorial sections for instructional focused content.
+
+.. tip::
+   See the sidebar for a full list of topics covered in this Reference Manual.
+
+:ref:`ref-docker` covers topics related to Factory containers and Compose Apps.
+This includes an architecture overview, how third party registries such as those from Amazon, Google, and Azure are configured, and Restorable Apps.
+
+:ref:`ref-factory` provides details on the tools and services that you have access to for working with and customizing your Factory. 
+
+:ref:`Linux microPlatform (LmP) <ref-linux>` covers supported machines, OpenEmbedded/Yocto Project layers and tools such as building a Yocto Project Software Development Kit (SDK), and working with the kernel.
+
+:ref:`ref-ota`: OTA Update related topics including: tools, production Targets, device tags, and clients.
+
+:ref:`ref-security` goes over a wide spectrum of security related topics including device boot, connecting to cloud services, and secure updates.
+


### PR DESCRIPTION
Added `reference-manual/index.rst` as a summary/landing page for the reference manual.

Note not every topic was mentioned; the RM section itself is likely to be thinned out, as many pages are more appropriate for the user guide.

QA: ran linkcheck, checked html output in browser, ran linter.

This commit applies to:

Jira FFTK-1973

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

