### PR TITLE
Reorg flash page

### DIFF
--- a/source/reference-manual/boards/imx-common-board.inc
+++ b/source/reference-manual/boards/imx-common-board.inc
@@ -1,0 +1,148 @@
+Preparation
+-----------
+
+|secure_boot_preparation_note|
+
+Ensure you replace the ``<factory>`` placeholder below with the name of your
+Factory.
+
+#. Download necessary files from ``https://app.foundries.io/factories/<factory>/targets``
+
+     a. Click the latest :guilabel:`Target` with the ``platform-devel`` :guilabel:`Trigger`.
+
+          .. figure:: /_static/boards/generic-steps-1.png
+            :width: 769
+            :align: center
+
+     #. Expand the **run** in the :guilabel:`Runs` section which corresponds
+        with the name of the board and **download the Factory image for that
+        machine.**
+
+        | E.g:
+        |     ``lmp-factory-image-<machine_name>.wic.gz``
+        |     ``u-boot-<machine_name>.itb``
+        |     ``imx-boot-<machine_name>``
+
+          .. figure:: /_static/boards/generic-steps-2.png
+            :width: 769
+            :align: center
+
+#. Extract the file ``lmp-factory-image-<machine_name>.wic.gz``:
+
+     .. parsed-literal::
+
+      gunzip lmp-factory-image-|machine_name|.wic.gz
+
+#. Download and extract the file ``mfgtool-files-<machine_name>.tar.gz``:
+
+     .. parsed-literal::
+
+      tar -zxvf mfgtool-files-|machine_name|.tar.gz
+
+#. Organize all the files like the tree below:
+
+     |imx_file_list|
+
+Hardware Preparation
+--------------------
+
+Set up the board for updating using the manufacturing tools:
+
+|image_board_top|
+
+Top view of |board_name|
+
+#. **OPTIONAL**—Only required if you have problems or want to see the boot console output.
+
+     Connect the |imx_usb_type_debug| end of the USB cable into debug port |debug_port|.
+     Connect the other end of the cable to a PC acting as a host
+     terminal. |imx_n_consoles| UART connections will appear on the PC.
+     On a Linux host for example:
+
+     |imx_tty_list|
+
+     Using a serial terminal program like `minicom <https://salsa.debian.org/minicom-team/minicom>`_,
+     connect to the port with |imx_tty_port| in the name (in this example |imx_tty_device|)
+     and apply the following configuration:
+
+          - Baud rate: 115200
+          - Data bits: 8
+          - Stop bit: 1
+          - Parity: None
+          - Flow control: None
+
+#. Ensure that the power is off (|power_switch|)
+
+#. Put the |board_name| into programing mode:
+
+     Switch |boot_mode_switch| to |boot_mode_sdp| (from |boot_mode_bits| bit) to Download Mode.
+
+     |image_board_SW|
+
+     Location of |boot_mode_switch| dip switch on |board_name|
+
+#. Connect your computer to the |board_name| board via the |imx_usb_type_sdp| port 1 ``Download`` |download_port| jack.
+
+#. Connect the |imx_power_jack_type| power plug to the port 2 ``Power`` |power_jack| jack.
+
+#. Power on the |board_name| board by sliding power switch |power_switch| to ON.
+
+Flashing
+--------
+
+Once in serial downloader mode and connected to your PC the evaluation board
+should show up as an NXP® USB device.
+
+|secure_boot_pre_flash_note|
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      #. Verify target is present:
+
+         |imx_lsusb|
+
+         In this mode you will use the ``uuu`` tools to program the images to the eMMC. The USB
+         ID may differ if a different SoC is used.
+
+      #. Run the command below to program the LmP to the EMMC:
+
+          .. parsed-literal::
+
+           $ sudo mfgtool-files-|machine_name|/uuu mfgtool-files-|machine_name|/full_image.uuu
+             uuu (Universal Update Utility) for nxp imx chips -- libuuu_1.4.243-0-ged48c51
+
+             Success 1    Failure 0
+
+
+             1:92     6/ 6 [Done                                  ] FB: done
+
+      #. Turn off the power.
+      #. Put the board into run mode
+
+   .. group-tab:: Windows
+
+      #. Start the ``Device Manager``
+      #. Select ``View``
+      #. Select ``Devices by container``
+      #. Verify a device like the following:  |usb_device_windows|
+      #. Run the command below to program the LmP to the EMMC:
+
+          .. parsed-literal::
+
+           C:\\Users\\Someone> mfgtool-files-|machine_name|\\uuu.exe mfgtool-files-|machine_name|\\full_image.uuu
+             uuu (Universal Update Utility) for nxp imx chips -- libuuu_1.4.243-0-ged48c51
+
+             Success 1    Failure 0
+
+
+             1:92     6/ 6 [Done                                  ] FB: done
+
+      #. Turn off the power.
+      #. Put the board into run mode
+
+Put the |board_name| into run mode by switching |boot_mode_switch|
+to |boot_mode_emmc| to set the board to boot from eMMC.
+
+Power on the |board_name| board by sliding the power switch |power_switch| to ON.

--- a/source/reference-manual/boards/imx6ul.rst
+++ b/source/reference-manual/boards/imx6ul.rst
@@ -3,96 +3,76 @@
 i.MX 6UL Evaluation Kit
 ========================
 
-.. include:: imx6ul-prepare.rst
+.. |board_name| replace:: imx6ulevk
+.. |machine_name| replace:: imx6ulevk
+.. |debug_port| replace:: **J1901**
+.. |download_port| replace:: **USB OTG**
+.. |power_jack| replace:: **J2001**
+.. |power_switch| replace:: **SW2001**
+.. |boot_mode_switch| replace:: **SW602**
+.. |boot_mode_sdp| replace:: OFF, ON
+.. |boot_mode_emmc| replace:: ON, OFF
+.. |boot_mode_bits| replace:: 1-2
+.. |imx_usb_type| replace:: micro-B
+.. |imx_n_consoles| replace:: One
+.. |imx_tty_device| replace:: ``ttyUSB2``
+.. |imx_tty_port| replace:: ``if00``
+.. |imx_usb_type_debug| replace:: micro-B
+.. |imx_usb_type_sdp| replace:: micro-B
+.. |imx_power_jack_type| replace:: 5V
 
-Hardware Preparation
---------------------
+.. |imx_lsusb| prompt:: bash $, auto
 
-Set up the board for updating using the manufacturing tools:
+                $ lsusb | grep NXP
+                  Bus 002 Device 052: ID 15a2:0080 Freescale Semiconductor, Inc.
 
-.. figure:: /_static/boards/imx6ulevk.png
-     :width: 400
-     :align: center
+.. |image_board_top| image:: /_static/boards/imx6ulevk.png
+     :width: 600
+     :align: middle
 
-     imx6ulevk
+.. |image_board_SW| image:: /_static/boards/imx6ullevk_SW1.png
+     :width: 600
+     :align: middle
 
-#. **OPTIONAL** - Only required if you have a problems and/or want to see the boot console output.
+.. |imx_tty_list| prompt:: bash $, auto
 
-     Connect the micro-B end of the USB cable into debug port J1901.
-     Connect the other end of the cable to a PC acting as a host
-     terminal. One UART connection will appear on the PC.
-     On a Linux host for example::
-
-          $ ls -l /dev/serial/by-id/
+        $ ls -l /dev/serial/by-id/
           total 0
-          lrwxrwxrwx 1 root root 13 лис 28 15:29 usb-Prolific_Technology_Inc._USB-Serial_Controller-if00-port0 -> ../../ttyUSB3
+          lrwxrwxrwx 1 root root 13 Dec  3 13:09 usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0 -> ../../ttyUSB2
 
-     Using a serial terminal program like minicom, connect to the port
-     with ``if00`` in the name (in this example ttyUSB3) and apply the
-     following configuration
+.. |usb_device_windows| image:: /_static/boards/imx6_windows.png
+          :width: 600
+          :align: middle
 
-          - Baud rate: 115200
-          - Data bits: 8
-          - Stop bit: 1
-          - Parity: None
-          - Flow control: None
+.. |imx_file_list| prompt:: text
 
-#. Ensure that the power is off (SW2001)
+          ├── lmp-factory-image-imx6ulevk.wic
+          ├── u-boot-imx6ulevk.itb
+          ├── sit-imx6ulevk.bin
+          ├── SPL-imx6ulevk
+          └── mfgtool-files-imx6ulevk
+               ├── bootloader.uuu
+               ├── full_image.uuu
+               ├── SPL-mfgtool
+               ├── u-boot-mfgtool.itb
+               ├── uuu
+               └── uuu.exe
 
-#. Put the imx6ulevk into programing mode:
+.. |secure_boot_preparation_note| replace:: The instructions in this section
+     show the preparation before the flashing procedure.
 
-     Switch SW602 to boot from serial downloader by setting to OFF, ON (from 1-2 bit)
+.. |secure_boot_pre_flash_note| replace:: Follow the instructios below.
 
-     .. figure:: /_static/boards/imx6ullevk_SW1.png
-          :width: 300
-          :align: center
+Pre-preparation
+---------------
 
-          SW602 settings
-
-+----------+-----------+-----------------------+
-| D1/MODE1 | D2/MODE0  |  BOOT MODE            |
-+==========+===========+=======================+
-|  OFF     |  OFF      | Boot From Fuses       |
-+----------+-----------+-----------------------+
-| **OFF**  | **ON**    | **Serial Downloader** |
-+----------+-----------+-----------------------+
-|  ON      |  OFF      | Internal Boot         |
-+----------+-----------+-----------------------+
-|  ON      |  ON       | Reserved              |
-+----------+-----------+-----------------------+
-
-     Switch SW601 to device microSD by setting to OFF, OFF, ON, OFF (from 1-4 bit)
+Before starting to work with |board_name| make sure to switch **SW601** to device
+microSD by setting to OFF, OFF, ON, OFF (from 1-4 bit)
 
      .. figure:: /_static/boards/imx6_sw601.png
           :width: 300
           :align: center
 
-          SW601 settings
+          **SW601** settings
 
-+----------+-----------+----------+-----------+-----------------------+
-| D1       | D2        | D3       | D4        |  BOOT MODE            |
-+==========+===========+==========+===========+=======================+
-| **OFF**  | **OFF**   | **ON**   | **OFF**   | **MicroSD**           |
-+----------+-----------+----------+-----------+-----------------------+
-| OFF      | OFF       | OFF      | OFF       | QSPI                  |
-+----------+-----------+----------+-----------+-----------------------+
-| OFF      | ON        | ON       | OFF       | EMMC                  |
-+----------+-----------+----------+-----------+-----------------------+
-| ON       | ON        | OFF      | ON        | NAND                  |
-+----------+-----------+----------+-----------+-----------------------+
-
-#. Connect your computer to the EVK board via the USB OTG jack.
-#. Connect the plug of the 5V power supply to the DC power jack J2001.
-#. Power on the EVK board by sliding power switch SW2001 to ON.
-
-Flashing
---------
-
-Once in serial downloader mode and connected to your PC the evaluation board should show up as a Freescale USB device.
-
-.. include:: imx6-flashing.rst
-
-To put the EVK into run mode, switch SW602 to ``internal boot`` by setting to
-ON, OFF (from 1-2bit). This is the opposite of programming mode described previously.
-
-Power on the EVK board by sliding power switch SW2001 to ON.
+.. include:: imx-common-board.inc

--- a/source/reference-manual/boards/imx6ull.rst
+++ b/source/reference-manual/boards/imx6ull.rst
@@ -3,100 +3,81 @@
 i.MX 6ULL Evaluation Kit
 ========================
 
-.. include:: secure-boot-note.rst
+.. |board_name| replace:: imx6ullevk
+.. |machine_name| replace:: imx6ullevk
+.. |debug_port| replace:: **J1901**
+.. |download_port| replace:: **USB OTG**
+.. |power_jack| replace:: **J2001**
+.. |power_switch| replace:: **SW2001**
+.. |boot_mode_switch| replace:: **SW602**
+.. |boot_mode_sdp| replace:: OFF, ON
+.. |boot_mode_emmc| replace:: ON, OFF
+.. |boot_mode_bits| replace:: 1-2
+.. |imx_usb_type| replace:: micro-B
+.. |imx_n_consoles| replace:: One
+.. |imx_tty_device| replace:: ``ttyUSB2``
+.. |imx_tty_port| replace:: ``if00``
+.. |imx_usb_type_debug| replace:: micro-B
+.. |imx_usb_type_sdp| replace:: micro-B
+.. |imx_power_jack_type| replace:: 5V
 
-.. include:: imx6ull-prepare.rst
+.. |imx_lsusb| prompt:: bash $, auto
 
-Hardware Preparation
---------------------
+                $ lsusb | grep NXP
+                  Bus 002 Device 052: ID 15a2:0080 Freescale Semiconductor, Inc.
 
-Set up the board for updating using the manufacturing tools:
+.. |image_board_top| image:: /_static/boards/imx6ullevk.png
+     :width: 600
+     :align: middle
 
-.. figure:: /_static/boards/imx6ullevk.png
-     :width: 400
-     :align: center
+.. |image_board_SW| image:: /_static/boards/imx6ullevk_SW1.png
+     :width: 600
+     :align: middle
 
-     imx6ullevk
+.. |imx_tty_list| prompt:: bash $, auto
 
-#. **OPTIONAL** - Only required if you have a problems and/or want to see the boot console output.
-
-     Connect the micro-B end of the USB cable into debug port J1901.
-     Connect the other end of the cable to a PC acting as a host
-     terminal. One UART connection will appear on the PC.
-     On a Linux host for example::
-
-          $ ls -l /dev/serial/by-id/
+        $ ls -l /dev/serial/by-id/
           total 0
           lrwxrwxrwx 1 root root 13 Dec  3 13:09 usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0 -> ../../ttyUSB2
 
-     Using a serial terminal program like minicom, connect to the port
-     with ``if00`` in the name (in this example ttyUSB2) and apply the
-     following configuration
+.. |usb_device_windows| image:: /_static/boards/imx6_windows.png
+          :width: 600
+          :align: middle
 
-          - Baud rate: 115200
-          - Data bits: 8
-          - Stop bit: 1
-          - Parity: None
-          - Flow control: None
+.. |imx_file_list| prompt:: text
 
-#. Ensure that the power is off (SW2001)
+          ├── lmp-factory-image-imx6ullevk.wic
+          ├── u-boot-imx6ullevk.itb
+          ├── sit-imx6ullevk.bin
+          ├── SPL-imx6ullevk
+          └── mfgtool-files-imx6ullevk
+               ├── bootloader.uuu
+               ├── full_image.uuu
+               ├── SPL-mfgtool
+               ├── u-boot-mfgtool.itb
+               ├── uuu
+               └── uuu.exe
 
-#. Put the imx6ullevk into programing mode:
+.. |secure_boot_preparation_note| replace::
+    The instructions in this section also applies to those boards with secure
+    boot enabled. There are references on how to perform common instructions
+    along with the flow. The :ref:`ref-security` Reference Manual details the
+    required background for secure boot.
 
-     Switch SW602 to boot from serial downloader by setting to OFF, ON (from 1-2 bit)
+.. |secure_boot_pre_flash_note| replace:: For instructions on how to sign the
+     required images before flashing them to the board with secure boot enabled,
+     follow the instructions from :ref:`ref-secure-machines`.
 
-     .. figure:: /_static/boards/imx6ullevk_SW1.png
-          :width: 300
-          :align: center
+Pre-preparation
+---------------
 
-          SW602 settings
-
-+----------+-----------+-----------------------+
-| D1/MODE1 | D2/MODE0  |  BOOT MODE            |
-+==========+===========+=======================+
-|  OFF     |  OFF      | Boot From Fuses       |
-+----------+-----------+-----------------------+
-| **OFF**  | **ON**    | **Serial Downloader** |
-+----------+-----------+-----------------------+
-|  ON      |  OFF      | Internal Boot         |
-+----------+-----------+-----------------------+
-|  ON      |  ON       | Reserved              |
-+----------+-----------+-----------------------+
-
-     Switch SW601 to device microSD by setting to OFF, OFF, ON, OFF (from 1-4 bit)
+Before starting to work with |board_name| make sure to switch **SW601** to device
+microSD by setting to OFF, OFF, ON, OFF (from 1-4 bit)
 
      .. figure:: /_static/boards/imx6_sw601.png
           :width: 300
           :align: center
 
-          SW601 settings
+          **SW601** settings
 
-+----------+-----------+----------+-----------+-----------------------+
-| D1       | D2        | D3       | D4        |  BOOT MODE            |
-+==========+===========+==========+===========+=======================+
-| **OFF**  | **OFF**   | **ON**   | **OFF**   | **MicroSD**           |
-+----------+-----------+----------+-----------+-----------------------+
-| OFF      | OFF       | OFF      | OFF       | QSPI                  |
-+----------+-----------+----------+-----------+-----------------------+
-| OFF      | ON        | ON       | OFF       | EMMC                  |
-+----------+-----------+----------+-----------+-----------------------+
-|  ON      |  ON       | OFF      | ON        | NAND                  |
-+----------+-----------+----------+-----------+-----------------------+
-
-#. Connect your computer to the EVK board via the USB OTG jack.
-#. Connect the plug of the 5V power supply to the DC power jack J2001.
-#. Power on the EVK board by sliding power switch SW2001 to ON.
-
-Flashing
---------
-
-Once in serial downloader mode and connected to your PC the evaluation board should show up as a Freescale USB device.
-
-.. include:: secure-boot-pre-flash-note.rst
-
-.. include:: imx6-flashing.rst
-
-To put the EVK into run mode, switch SW602 to ``internal boot`` by setting to
-ON, OFF (from 1-2bit). This is the opposite of programming mode described previously.
-
-Power on the EVK board by sliding power switch SW2001 to ON.
+.. include:: imx-common-board.inc

--- a/source/reference-manual/boards/imx8ulpevk.rst
+++ b/source/reference-manual/boards/imx8ulpevk.rst
@@ -4,6 +4,7 @@ i.MX 8 ULP Evaluation Kit
 =========================
 
 .. |board_name| replace:: i.MX 8 ULP EVK
+.. |machine_name| replace:: imx8ulp-lpddr4-evk
 .. |debug_port| replace:: **J17**
 .. |download_port| replace:: **J15**
 .. |power_jack| replace:: **SW10**
@@ -12,26 +13,28 @@ i.MX 8 ULP Evaluation Kit
 .. |boot_mode_sdp| replace:: X, X, X, X, X, X, ON, OFF
 .. |boot_mode_emmc| replace:: OFF, OFF, X, X, OFF, OFF, OFF, ON
 .. |boot_mode_bits| replace:: 1-8
+.. |imx_usb_type| replace:: micro-C
+.. |imx_n_consoles| replace:: Three
+.. |imx_tty_device| replace:: ``ttyUSB2``
+.. |imx_tty_port| replace:: ``if02``
+.. |imx_usb_type_debug| replace:: micro-B
+.. |imx_usb_type_sdp| replace:: USB-C
+.. |imx_power_jack_type| replace:: USB-C
 
-.. include:: imx8-prepare.rst
+.. |imx_lsusb| prompt:: bash $, auto
 
-Hardware Preparation
---------------------
+           $ lsusb | grep NXP
+           Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
-Set up the board for updating using the manufacturing tools:
-
-.. figure:: /_static/boards/imx8ulp-lpddr4-evk.png
+.. |image_board_top| image:: /_static/boards/imx8ulp-lpddr4-evk.png
      :width: 600
-     :align: center
+     :align: middle
 
-     |board_name|
+.. |image_board_SW| image:: /_static/boards/imx8ulp-lpddr4-evk_SW.png
+     :width: 600
+     :align: middle
 
-#. **OPTIONAL**—Only required if you have problems and/or want to see the boot console output.
-
-     Connect the micro-B end of the USB cable into debug port |debug_port|.
-     Connect the other end of the cable to a PC acting as a host
-     terminal. Three UART connections will appear on the PC.
-     On a Linux host for example::
+.. |imx_tty_list| prompt:: bash $, auto
 
         $ ls -l /dev/serial/by-id/
         total 0
@@ -39,41 +42,26 @@ Set up the board for updating using the manufacturing tools:
         lrwxrwxrwx 1 root root 13 Feb 13 12:59 usb-0403_FT4232H_9266A2-if02-port0 -> ../../ttyUSB2
         lrwxrwxrwx 1 root root 13 Feb 13 12:59 usb-0403_FT4232H_9266A2-if03-port0 -> ../../ttyUSB3
 
-     Using a serial terminal program like `minicom <https://salsa.debian.org/minicom-team/minicom>`_, connect to the port
-     with ``if02`` in the name (in this example ttyUSB2) and apply the
-     following configuration:
-
-          - Baud rate: 115200
-          - Data bits: 8
-          - Stop bit: 1
-          - Parity: None
-          - Flow control: None
-
-#. Ensure that the power is off (|power_switch|)
-
-#. Put the |board_name| into programing mode:
-
-     Switch |boot_mode_switch| to |boot_mode_sdp| (from |boot_mode_bits| bit) to Download Mode.
-
-     .. figure:: /_static/boards/imx8ulp-lpddr4-evk_SW.png
+.. |usb_device_windows| image:: /_static/boards/windows_verify.png
           :width: 600
-          :align: center
+          :align: middle
 
-          |boot_mode_switch| programing settings
+.. |imx_file_list| prompt:: text
 
-#. Connect your computer to the |board_name| board via the USB Type-C port 1 ``Download`` |download_port| jack.
-#. Connect the USB Type-C power plug to the port 2 ``Power`` |power_jack| jack.
+          ├── lmp-factory-image-imx8ulp-lpddr4-evk.wic
+          ├── u-boot-imx8ulp-lpddr4-evk.itb
+          ├── imx-boot-imx8ulp-lpddr4-evk
+          └── mfgtool-files-imx8ulp-lpddr4-evk
+               ├── bootloader.uuu
+               ├── full_image.uuu
+               ├── SPL-mfgtool
+               ├── u-boot-mfgtool.itb
+               ├── uuu
+               └── uuu.exe
 
-#. Power on the |board_name| board by sliding power switch |power_switch| to ON.
+.. |secure_boot_preparation_note| replace:: The instructions in this section
+     show the preparation before the flashing procedure.
 
-Flashing
---------
+.. |secure_boot_pre_flash_note| replace:: Follow the instructios below.
 
-Once in serial downloader mode and connected to your PC the evaluation board should show up as an NXP® USB device.
-
-
-.. include:: imx8-flashing.rst
-
-To put the |board_name| into run mode by switching |boot_mode_switch| to |boot_mode_emmc| to set Cortex-A to boot from eMMC.
-
-Power on the |board_name| board by sliding power switch |power_switch| to ON.
+.. include:: imx-common-board.inc

--- a/source/reference-manual/boards/imx93evk.rst
+++ b/source/reference-manual/boards/imx93evk.rst
@@ -4,6 +4,7 @@ i.MX 93 Evaluation Kit
 ======================
 
 .. |board_name| replace:: i.MX 93 EVK
+.. |machine_name| replace:: imx93-11x11-lpddr4x-evk
 .. |debug_port| replace:: **J1401**
 .. |download_port| replace:: **J401**
 .. |power_jack| replace:: **J301**
@@ -12,69 +13,56 @@ i.MX 93 Evaluation Kit
 .. |boot_mode_sdp| replace:: OFF, OFF, ON, ON
 .. |boot_mode_emmc| replace:: ON, ON, ON, ON
 .. |boot_mode_bits| replace:: 1-4
+.. |imx_usb_type| replace:: USB-C
+.. |imx_n_consoles| replace:: Four
+.. |imx_tty_device| replace:: ``ttyUSB2``
+.. |imx_tty_port| replace:: ``if02``
+.. |imx_usb_type_debug| replace:: USB-C
+.. |imx_usb_type_sdp| replace:: USB-C
+.. |imx_power_jack_type| replace:: USB-C
 
+.. |imx_lsusb| prompt:: bash $, auto
 
-.. include:: imx8-prepare.rst
+                $ lsusb | grep NXP
+                  Bus 001 Device 018: ID 1fc9:014e NXP Semiconductors OO Blank 93
 
-Hardware Preparation
---------------------
-
-Set up the board for updating using the manufacturing tools:
-
-.. figure:: /_static/boards/imx93evk.png
+.. |image_board_top| image:: /_static/boards/imx93evk.png
      :width: 600
-     :align: center
+     :align: middle
 
-     |board_name|
+.. |image_board_SW| image:: /_static/boards/imx93evk_SW.png
+     :width: 600
+     :align: middle
 
-#. **OPTIONAL**—Only required if you have problems and/or want to see the boot console output.
+.. |imx_tty_list| prompt:: bash $, auto
 
-     Connect the micro-B end of the USB cable into debug port |debug_port|.
-     Connect the other end of the cable to a PC acting as a host
-     terminal. Four UART connections will appear on the PC.
-     On a Linux host for example::
+          ls -l /dev/serial/by-id/
+           total 0
+           lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if00-port0 -> ../../ttyUSB0
+           lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if01-port0 -> ../../ttyUSB1
+           lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if02-port0 -> ../../ttyUSB2
+           lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if03-port0 -> ../../ttyUSB3
 
-          $ ls -l /dev/serial/by-id/
-          total 0
-          lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if00-port0 -> ../../ttyUSB0
-          lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if01-port0 -> ../../ttyUSB1
-          lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if02-port0 -> ../../ttyUSB2
-          lrwxrwxrwx 1 root root 13 abr 20 16:20 usb-FTDI_Quad_RS232-HS-if03-port0 -> ../../ttyUSB3
-
-     Using a serial terminal program like `minicom <https://salsa.debian.org/minicom-team/minicom>`_, connect to the port
-     with ``if02`` in the name (in this example ttyUSB2) and apply the
-     following configuration:
-
-          - Baud rate: 115200
-          - Data bits: 8
-          - Stop bit: 1
-          - Parity: None
-          - Flow control: None
-
-#. Ensure that the power is off (|power_switch|)
-
-#. Put the |board_name| into programing mode:
-
-     Switch |boot_mode_switch| to |boot_mode_sdp| (from |boot_mode_bits| bit) to Download Mode.
-
-     .. figure:: /_static/boards/imx93evk_SW.png
+.. |usb_device_windows| image:: /_static/boards/windows_verify.png
           :width: 600
-          :align: center
+          :align: middle
 
-          |boot_mode_switch| dip switch
+.. |imx_file_list| prompt:: text
 
-#. Connect your computer to the |board_name| board via the USB Type-C port 1 ``Download`` |download_port| jack.
-#. Connect the USB Type-C power plug to the port 2 ``Power`` |power_jack| jack.
+          ├── lmp-factory-image-imx93-11x11-lpddr4x-evk.wic
+          ├── u-boot-imx93-11x11-lpddr4x-evk.itb
+          ├── imx-boot-imx93-11x11-lpddr4x-evk
+          └── mfgtool-files-imx93-11x11-lpddr4x-evk
+               ├── bootloader.uuu
+               ├── full_image.uuu
+               ├── SPL-mfgtool
+               ├── u-boot-mfgtool.itb
+               ├── uuu
+               └── uuu.exe
 
-#. Power on the |board_name| board by sliding power switch |power_switch| to ON.
+.. |secure_boot_preparation_note| replace:: The instructions in this section
+     show the preparation before the flashing procedure.
 
-Flashing
---------
+.. |secure_boot_pre_flash_note| replace:: Follow the instructions below.
 
-Once in serial downloader mode and connected to your PC the evaluation board should show up as an NXP® USB device.
-
-.. include:: imx9-flashing.rst
-
-To put the |board_name| into run mode by switching |boot_mode_switch| to |boot_mode_emmc| to set Cortex-A to boot from eMMC.
-
-Power on the |board_name| board by sliding power switch |power_switch| to ON.
+.. include:: imx-common-board.inc


### PR DESCRIPTION
Please review and let me know what you think 

## Overview

The goal is to get the maximum text reuse for the flashing pages by using variables to replace some key texts.

The converted boards so far:

* imx6ulevk - https://ci.foundries.io/projects/fio-docs/builds/2244/docs/artifacts/html/reference-manual/boards/imx6ul.html
* imx6ullevk - https://ci.foundries.io/projects/fio-docs/builds/2244/docs/artifacts/html/reference-manual/boards/imx6ull.html
* imx8ulpevk - https://ci.foundries.io/projects/fio-docs/builds/2244/docs/artifacts/html/reference-manual/boards/imx8ulpevk.html
* imx93evk - https://ci.foundries.io/projects/fio-docs/builds/2244/docs/artifacts/html/reference-manual/boards/imx93evk.html

Unchanged:

* imx8mnevk
* imx8mmevk
* imx8mqevk
* apalis6
* apalis8

## Changes

It uses variables to replace some texts and one file to use those variables. Some images are generic. Some are defined as variables on the board page.

Some code blocks were replaced by `parsed-literal` blocks to get the variable working. They have different background colors (green/white). Take a look to see if this is acceptable or if it's preferable to let the generic text there.

In the **Preparation** section, step 1, substep **a** and **b**, and use a generic screenshot. The goal here is to reduce the number of screenshots. However, we may decide to keep one screenshot per board (currently the doc is not consistent at this point)

## Error

When a board file does not define one variable, the error shown is:
```
source/reference-manual/boards/imx-common-board.inc:4:Undefined substitution referenced: "secure_boot_preparation_note".
```

And you don't have a clue on which is the board to fix.

