### PR TITLE
Add link to qemu section

### DIFF
--- a/source/getting-started/flash-device/index.rst
+++ b/source/getting-started/flash-device/index.rst
@@ -52,10 +52,12 @@ After a successful build, FoundriesFactory produces build artifacts which can be
 Flashing the Image
 ------------------
 
-The flashing procedure is board specific and we cover separate steps in :ref:`ref-boards`. Please refer to this section for specifics on flashing your system image using the vendor provided tools.
+The flashing procedure is board specific and we cover separate steps in :ref:`ref-boards`.
+Please refer to this section for specifics on flashing your system image using the vendor provided tools.
+See :ref:`ref-qemu` for booting Qemu images.
 
 .. note::
-    LmP enforces eMMC boot whenever possible as this is the path to enable all security features it provides. So for platforms with available eMMC, such as the NXP® i.MX EVKs, booting from eMMC rather than SD is highly recommended and enabled by default.
+   LmP enforces eMMC boot whenever possible as this is the path to enable all security features it provides. So for platforms with available eMMC, such as the NXP® i.MX EVKs, booting from eMMC rather than SD is highly recommended and enabled by default.
 
 .. _gs-boot:
 


### PR DESCRIPTION
While qemu images don't need to be flashed, the following section jumps right into connecting to the network, and it seemed appropriate to have a link to the qemu section.

QA: Checked rendered html.

No issue to link, minor fix.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Figured the Qemu page should be linked to.

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments
