### PR TITLE
Add instructions on expandable Qemu disk images

### DIFF
--- a/source/reference-manual/qemu/arm-substitutions.inc
+++ b/source/reference-manual/qemu/arm-substitutions.inc
@@ -11,4 +11,16 @@
      fioctl targets artifacts <target_number> |MACHINE|/lmp-factory-image-|MACHINE|.wic.gz | gunzip > lmp-factory-image-|MACHINE|.wic
      # Download ATF + OP-TEE + U-Boot binary
      fioctl targets artifacts <target_number> |MACHINE|/other/|FIRMWARE_BLOB| > |FIRMWARE_BLOB|
+     # If resizing disk image, download the qcow2 file
+     fioctl targets artifacts <target_number> |MACHINE|/other/lmp-factory-image-|MACHINE|.wic.qcow2 > lmp-factory-image-|MACHINE|.wic.qcow2
 
+.. |QEMU_COW| replace::
+   
+     qemu-system-arm -machine virt,highmem=off -cpu cortex-a7 -m 1024M \\
+     -bios u-boot-qemuarm.bin \\
+     -serial mon:vc -serial null \\
+     -drive id=disk0,file=mp-factory-image-qemuarm.wic.qcow2,if=none,format=qcow2 -device virtio-blk-device,drive=disk0 \\
+     -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \\
+     -device virtio-net-device,netdev=usernet \\
+     -netdev user,id=usernet,hostfwd=tcp::22222-:22 \\
+     -no-acpi -d unimp -nographic

--- a/source/reference-manual/qemu/arm64-substitutions.inc
+++ b/source/reference-manual/qemu/arm64-substitutions.inc
@@ -11,4 +11,14 @@
      fioctl targets artifacts <target_number> |MACHINE|/lmp-factory-image-|MACHINE|.wic.gz | gunzip > lmp-factory-image-|MACHINE|.wic
      # Download ATF + OP-TEE + U-Boot binary
      fioctl targets artifacts <target_number> |MACHINE|/|FIRMWARE_BLOB| > |FIRMWARE_BLOB|
+     # If resizing disk image, download the qcow2 file
+     fioctl targets artifacts <target_number> |MACHINE|/other/lmp-factory-image-|MACHINE|.wic.qcow2 > lmp-factory-image-|MACHINE|.wic.qcow2
 
+.. |QEMU_COW| replace::
+
+     qemu-system-aarch64 -m 1024 -cpu cortex-a57 -no-acpi -bios flash.bin \\
+     -device virtio-net-device,netdev=net0,mac=52:54:00:12:35:02 -device virtio-serial-device \\
+     -drive id=disk0,file=lmp-factory-image-qemuarm64-secureboot.wic.qcow2,if=none,format=qcow2 \\
+     -device virtio-blk-device,drive=disk0 -netdev user,id=net0,hostfwd=tcp::2222-:22 \\
+     -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \\
+     -chardev null,id=virtcon -machine virt,secure=on -nographic

--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -4,7 +4,14 @@
 
      └── |ARCH|
          ├── lmp-factory-image-|MACHINE|.wic.gz
+         ├── other
+         │   └── lmp-factor-image-|MACHINE|.wic.qcow2 # optional
          └── |FIRMWARE_BLOB|
+
+.. note::
+    You can fetch either the compressed ``.wic.gz`` or the ``.qcow2`` artifact, you do not need both.
+    Use the .qcow2 artifact if you wish to change the QEMU disk size.
+
 
 Booting in QEMU
 ---------------
@@ -35,6 +42,25 @@ Booting in QEMU
 
         |ARTIFACT_COMMANDS|
 
+#. `Optional`. Resize the qcow2 image:
+
+   .. parsed-literal::
+
+        qemu-img resize -f qcow2 lmp-factory-image-|MACHINE|.wic.qcow2 8G
+   
+   The above example resizes to 8G—set to meet your needs.
+
+   .. tip::
+       
+       If you already have the wic file, you can use it to create a qcow image:
+
+       .. parsed-literal::
+            
+            qemu-img create -f qcow2 -F raw -b lmp-factory-image-|MACHINE|.wic lmp-factory-image-|MACHINE|.wic.qcow2
+      
+      You can then use ``qemu-img resize`` as above.
+            
+ 
 #. The directory tree should now look like this:
 
    .. parsed-literal::
@@ -42,10 +68,23 @@ Booting in QEMU
         lmp-qemu/
         └── |ARCH|
             ├── lmp-factory-image-|MACHINE|.wic
+            ├── lmp-factory-image-|MACHINE|.wic.qcow2 # optional, needed if resizing is required
             └── |FIRMWARE_BLOB|
 
 #. Run the QEMU script below against the artifacts inside of ``lmp-qemu/``.
    You can save this as ``run.sh`` inside the directory for convenience.
+
+.. important::
+    If you are using the qcow2 image, change the script so that:
+
+       * ``file=`` is set as the qcow2 image name, i.e., lmp-factory-image-|MACHINE|.wic.qcow2
+       * ``format=raw`` is replaced with ``format=qcow2``.
+    
+    For example:
+       
+       .. parsed-literal::
+
+            |QEMU_COW|
 
 .. note::
     The QEMU CLI passes the necessary flags and parameters to the appropriate qemu-system command.
@@ -62,5 +101,4 @@ In order to boot QEMU with an OpenGL capable virtual GPU (required for Wayland/W
      |QEMU_GUI_FLAGS|
 
 Do not copy the ``-nographic`` flag at the end of the QEMU CLI below.
-
 

--- a/source/reference-manual/qemu/riscv64-substitutions.inc
+++ b/source/reference-manual/qemu/riscv64-substitutions.inc
@@ -11,3 +11,17 @@
      fioctl targets artifacts <target_number> |MACHINE|/lmp-factory-image-|MACHINE|.wic.gz | gunzip > lmp-factory-image-|MACHINE|.wic
      # Download OpenSBI Firmware
      fioctl targets artifacts <target_number> |MACHINE|/|FIRMWARE_BLOB| > |FIRMWARE_BLOB|
+     # If resizing disk image, download the qcow2 file
+     fioctl targets artifacts <target_number> |MACHINE|/other/lmp-factory-image-|MACHINE|.wic.qcow2 > lmp-factory-image-|MACHINE|.wic.qcow2
+
+.. |QEMU_COW| replace::
+
+     qemu-system-riscv64 -machine virt -m 1024 \\
+     -device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon \\
+     -device virtio-net-device,netdev=usernet \\
+     -netdev user,id=usernet,hostfwd=tcp::22222-:22 \\
+     -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-device,rng=rng0 \\
+     -bios fw_payload.elf \\
+     -monitor null \\
+     -drive file=lmp-factory-image-qemuriscv64.wic.qcow2,format=qcow2,id=hd0 -device virtio-blk-device,dri  ve=hd0 \\
+     -nographic

--- a/source/reference-manual/qemu/x86_64-substitutions.inc
+++ b/source/reference-manual/qemu/x86_64-substitutions.inc
@@ -11,4 +11,13 @@
      fioctl targets artifacts <target_number> |MACHINE|/lmp-factory-image-|MACHINE|.wic.gz | gunzip > lmp-factory-image-|MACHINE|.wic
      # Download OVMF UEFI Firmware
      fioctl targets artifacts <target_number> |MACHINE|/|FIRMWARE_BLOB| > |FIRMWARE_BLOB|
+     # If resizing disk image, download the wic.qcow2 file. This is different than the ovmf.secboot.qcow2!
+     fioctl targets artifacts <target_number> |MACHINE|/other/lmp-factory-image-|MACHINE|.wic.qcow2 > lmp-factory-image-|MACHINE|.wic.qcow2
 
+.. |QEMU_COW| replace::
+
+     qemu-system-x86_64 -m 1024 -cpu kvm64 -enable-kvm -serial mon:stdio -serial null \\
+     -drive file=lmp-factory-image-intel-corei7-64.wic.qcow2,format=qcow2,if=none,id=hd \\
+     -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd -device virtio-rng-pci \\
+     -drive if=pflash,format=qcow2,file=ovmf.secboot.qcow2 \\
+     -net user,hostfwd=tcp::22223-:22 -net nic -nographic


### PR DESCRIPTION
Added instructions on resizing qemu images, focusing on fetching the existing qcow2 file, with a tip on creating one from the wic file.

QA Steps: followed instructions on a macOS arm machine to boot a qemu-arm64 image without issue. Rendered and examined html output.

This commit addresses FFTK-2424

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Adds instructions for using a resizable qemu image to existing documentation.

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

This could also go on a separate page in the section rather than integrated as in this commit.
As the instructions for the x86-64 Qemu uses a UEFI cow2 file, I attempted to avoid confusion, however the templated nature of this section, while otherwise helpful, made this a bit more difficult. If it does seem confusing, I can rework it.
