### PR TITLE
Update for fast first target master to main

### DIFF
--- a/source/porting-guide/pg-spl-kernel.rst
+++ b/source/porting-guide/pg-spl-kernel.rst
@@ -5,7 +5,7 @@ Kernel and Device Tree
 
 The LmP goal is to be as close as possible to the mainline kernel when
 possible, or to use the community kernel support, depending on the board
-vendor. Supported kernel trees can be found `here <https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-bsp/recipes-kernel/linux>`_.
+vendor. Supported kernel trees can be found `here <https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-bsp/recipes-kernel/linux>`_.
 
 Unlike U-Boot, not all patches need to be appended to the kernel recipe.
 The user needs to append patches only to include features or drivers

--- a/source/porting-guide/pg-spl-uboot-fragments.rst
+++ b/source/porting-guide/pg-spl-uboot-fragments.rst
@@ -14,7 +14,7 @@ command.
 
 To create this file use the reference board support in LmP and modify
 the configuration files as needed. The list of supported boards and
-their ``.cfg`` files can be found `here <https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio>`_.
+their ``.cfg`` files can be found `here <https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio>`_.
 
 For example, see ``imx8mmevk/lmp-base.cfg``:
 

--- a/source/porting-guide/pg-spl-uboot.rst
+++ b/source/porting-guide/pg-spl-uboot.rst
@@ -5,7 +5,7 @@ U-Boot
 
 Get the latest U-Boot support from either the board vendor or the community.
 The current U-Boot versions supported in meta-lmp (u-boot-fio)
-can be found `here <https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-bsp/u-boot>`_.
+can be found `here <https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-bsp/u-boot>`_.
 If there is no U-Boot support for the target board or if it supports an
 old U-Boot version, the user should update/port to a newer U-Boot
 version as supported in ``u-boot-fio``.

--- a/source/reference-manual/docker/restorable-apps.rst
+++ b/source/reference-manual/docker/restorable-apps.rst
@@ -35,4 +35,4 @@ A user may extend the default list of Restorable Apps in the following ways:
 
 To disable Restorable Apps, a user should specify an empty string ``""`` as a value of ``<a comma-separated list of apps>`` in one of the previous options (e.g. ``lmp-device-register --restorable-apps ""``).
 
-.. _lmp-device-auto-register: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-support/lmp-device-auto-register
+.. _lmp-device-auto-register: https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-support/lmp-device-auto-register

--- a/source/reference-manual/factory/factory-definition.rst
+++ b/source/reference-manual/factory/factory-definition.rst
@@ -71,7 +71,7 @@ lmp
                 IMAGE: lmp-mini
                 EXAMPLE_VARIABLE_1: foo
            tagging:
-             refs/heads/master:
+             refs/heads/main:
                - tag: postmerge
              refs/heads/devel:
                - tag: devel
@@ -167,7 +167,7 @@ lmp:
   image_type: ``<mfg_image_type>``
       **Optional:** Sets the name of the recipe to use to build mfg_tools.
 
-      **Default:** ``mfgtool-files`` |br| (from `meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb <https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb>`_)
+      **Default:** ``mfgtool-files`` |br| (from `meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb <https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb>`_)
 
 .. _def-containers:
 
@@ -187,7 +187,7 @@ containers
              - arm64
              - amd64
            tagging:
-            refs/heads/master:
+            refs/heads/main:
               - tag: postmerge
             refs/heads/devel-foundries:
               - tag: devel
@@ -256,5 +256,5 @@ Optionally use a custom version of ci-scripts_ to perform CI builds.
 
    <br />
 
-.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-samples/images
+.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-samples/images
 .. _ci-scripts: https://github.com/foundriesio/ci-scripts

--- a/source/reference-manual/factory/factory-sources.rst
+++ b/source/reference-manual/factory/factory-sources.rst
@@ -70,8 +70,9 @@ Configuring CI to Build New Branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, ``meta-subscriber-overrides``, ``lmp-manifest`` and ``containers``
-have ``master`` and ``devel`` branches. ``ci-scripts`` only has the ``master``
-branch.
+have the single branch, ``main``.
+For these repos it is reccomended to also have a ``devel`` branch for non-production purposes.
+``ci-scripts`` has the single default branch ``master``.
 
 Platform Branches
 ^^^^^^^^^^^^^^^^^
@@ -83,8 +84,8 @@ To create new buildable platform branches, first enable the new branch in
 
     lmp:
       tagging:
-        refs/heads/master:
-          - tag: master
+        refs/heads/main:
+          - tag: main
         refs/heads/devel:
           - tag: devel
         refs/heads/new_branch:
@@ -127,8 +128,8 @@ To create new buildable container branches, first enable the new branch in
 
     containers:
       tagging:
-        refs/heads/master:
-          - tag: master
+        refs/heads/main:
+          - tag: main
         refs/heads/devel:
           - tag: devel
         refs/heads/new_branch:

--- a/source/reference-manual/linux/linux-oss-compliance.rst
+++ b/source/reference-manual/linux/linux-oss-compliance.rst
@@ -158,7 +158,7 @@ Change the file ``ci-scripts/factory-config.yml`` to include the variable
 
   lmp:
     ref_options:
-      refs/heads/master:
+      refs/heads/main:
         params:
           DISABLE_GPLV3: "1"
       refs/heads/devel:
@@ -183,7 +183,7 @@ It is important to note that, when using an image different than
 ``lmp-factory-image``, other packages might be used. In this case, the error
 message guides on which package to target.
 
-.. _image-license-checker: https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-base/classes/image-license-checker.bbclass
+.. _image-license-checker: https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/classes/image-license-checker.bbclass
 
 
 .. rubric:: Footnotes

--- a/source/reference-manual/linux/preloaded-images.rst
+++ b/source/reference-manual/linux/preloaded-images.rst
@@ -97,7 +97,7 @@ For example, let's assume you have 4 different branches with the following appli
      # devel and experimental:
      money-making-app - The "product"
      debug-tools      - A compose app with some tooling used for development
-     # master: 
+     # main: 
      money-making-app - The "product"
      fiotest          - A compose-app that some devices run for QA.
      # production:
@@ -122,7 +122,7 @@ This can be configured by additional variables on ``ref_options``.
 Let's assume you want to produce the following types of Targets:
 
  * ``devel`` preloaded with the ``money-making-app`` and ``debug-tools``.
- * ``master`` and ``production`` preloaded with the ``money-making-app``.
+ * ``main`` and ``production`` preloaded with the ``money-making-app``.
  * ``experiemental`` will not preload anything .
 
 This can be configured in `factory-config.yml` with:
@@ -133,10 +133,10 @@ This can be configured in `factory-config.yml` with:
         tagging:
          # Use a "production" branch, that may have some special platform
          # features enabled/disabled. However, it still uses the containers
-         # from master for its apps:
+         # from main for its apps:
           refs/heads/production:
             - tag: production
-              inherit: master
+              inherit: main
          ...
      
       containers:
@@ -145,9 +145,9 @@ This can be configured in `factory-config.yml` with:
           shortlist: "money-making-app"
      
         tagging:
-          # Changes to containers master create both "master" and "production" tagged targets
-          refs/heads/master:
-            - tag: master
+          # Changes to containers main create both "main" and "production" tagged targets
+          refs/heads/main:
+            - tag: main
             - tag: production
           refs/heads/devel:
             - tag: devel
@@ -184,7 +184,7 @@ be done using one off systemd service and image with pre-loaded containers.
 
 Example compose apps early start script can be found in meta-lmp:
 
-  https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-support/compose-apps-early-start
+  https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-support/compose-apps-early-start
 
 The recipe produces a systemd one off service and shell script.
 

--- a/source/reference-manual/ota/advanced-tagging.rst
+++ b/source/reference-manual/ota/advanced-tagging.rst
@@ -25,31 +25,31 @@ or this is a "production" build.
 Scenario 1: A new platform build that re-uses containers
 --------------------------------------------------------
 
-A Factory is set up with the normal ``master`` branch::
+A Factory is set up with the normal ``main`` branch::
 
   lmp:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
   containers:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
 
 You'd like to introduce a new ``stable`` branch from the LmP but have it use
 the latest containers from master. This can be done with::
 
   lmp:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
       refs/heads/stable:
         - tag: stable
-          inherit: master
+          inherit: main
   containers:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
         - tag: stable
 
 Consider this pseudo targets example::
@@ -62,11 +62,11 @@ Consider this pseudo targets example::
     build-2:
       ostree-hash: GOODBEEF
       compose-apps: foo:v2, bar:v2
-      tags: master
+      tags: main
 
 If a change to the stable branch was pushed to the LmP, a new
 target, build-3, would be added. The build logic would then look through
-the targets list to find the most recent ``master`` target so that
+the targets list to find the most recent ``main`` target so that
 it can copy those compose-apps. This would result in a new target::
 
   build-3:
@@ -74,7 +74,7 @@ it can copy those compose-apps. This would result in a new target::
     compose-apps: foo:v2, bar:v2
     tags: stable
 
-On the other hand, there might also be a new container build for ``master``.
+On the other hand, there might also be a new container build for ``main``.
 In this case the build logic will produce two new targets::
 
   build-4:  # for stable it will be based on build-3
@@ -85,28 +85,28 @@ In this case the build logic will produce two new targets::
   build-4:  # for master, it will be based on build-2
     ostree-hash: GOODBEEF
     compose-apps: foo:v3, bar:v3
-    tags: master
+    tags: main
 
 Scenario 2: Multiple container builds using the same platform
 -------------------------------------------------------------
 
 This scenario is the reverse of the previous one. A factory might have a
-platform build tagged with ``master``. However, there are two versions of
-containers being worked on: ``master`` and ``foo``. This could be handled
+platform build tagged with ``main``. However, there are two versions of
+containers being worked on: ``main`` and ``foo``. This could be handled
 with::
 
   lmp:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
         - tag: foo
   containers:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
       refs/heads/foo:
         - tag: foo
-          inherit: master
+          inherit: main
 
 Scenario 3: Multiple teams, different cadences
 ----------------------------------------------
@@ -118,25 +118,25 @@ development they are working on. This could be handled with something like::
 
   lmp:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
   containers:
     tagging:
-      refs/heads/master:
-        - tag: master
+      refs/heads/main:
+        - tag: main
       refs/heads/dev:
         - tag: dev
-          inherit: master
+          inherit: main
       refs/heads/qa:
         - tag: qa
-          inherit: master
+          inherit: main
 
-This scenario is going to produce ``master`` tagged builds that have no
+This scenario is going to produce ``main`` tagged builds that have no
 containers, but can be generically verified. Then each containers.git branch
-will build Targets and grab the latest ``master`` tag to base its platform
-on. **NOTE:** Changes to ``master`` don't cause new container builds. In
-order to get a container's branch updated to the latest ``master`` a user
+will build Targets and grab the latest ``main`` tag to base its platform
+on. **NOTE:** Changes to ``main`` don't cause new container builds. In
+order to get a container's branch updated to the latest ``main`` a user
 would need to push an empty commit to containers.git to trigger a new build::
 
  # from branch qa
- git commit --allow-empty -m 'Pull in latest platform changes from master'
+ git commit --allow-empty -m 'Pull in latest platform changes from main'

--- a/source/reference-manual/ota/static-deltas.rst
+++ b/source/reference-manual/ota/static-deltas.rst
@@ -33,7 +33,7 @@ by CI devices. For example, the targets.json might include::
   "raspberrypi4-64-lmp-9" : {
     "custom" : {
       "version": "9",
-      "tags" : ["master"],
+      "tags" : ["main"],
    ...
 
 In this example, Target #9 has passed CI and needs to be deployed to
@@ -66,7 +66,7 @@ that "promoted" devices will apply the update:
 
 .. prompt:: bash host:~$, auto
 
-   host:~$ fioctl targets tag --tags master,promoted --by-version 9
+   host:~$ fioctl targets tag --tags main,promoted --by-version 9
 
 When the CI job completes, devices on the promoted tag will start
 performing OTA updates that will use the static deltas.

--- a/source/reference-manual/security/authentication-xilinx.rst
+++ b/source/reference-manual/security/authentication-xilinx.rst
@@ -275,7 +275,7 @@ For more information on registering the PUF and how it is used by OP-TEE for gen
    https://docs.xilinx.com/r/aN5KSVyHt9jE~xaIBaKGSg/root
 
 .. _bitstream-signed:
-   https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed.bb
+   https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed.bb
 
 .. _lmp-tools:
    https://github.com/foundriesio/lmp-tools/tree/master/security/zynqmp

--- a/source/reference-manual/security/factory-registration-ref.rst
+++ b/source/reference-manual/security/factory-registration-ref.rst
@@ -158,4 +158,4 @@ reference server as per the README.md.
 .. _README.md:
    https://github.com/foundriesio/factory-registration-ref/blob/main/README.md
 .. _lmp-device-auto-register:
-   https://github.com/foundriesio/meta-lmp/blob/master/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
+   https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register

--- a/source/reference-manual/security/secure-boot-uefi.rst
+++ b/source/reference-manual/security/secure-boot-uefi.rst
@@ -82,7 +82,7 @@ Once PK is added by the user, most UEFI implementations move the active mode fro
 Creating UEFI Secure Boot Keys
 -----------------------------------
 
-The suggested way to create a custom set of UEFI Secure Boot keys and certificates is via the `lmp-tools gen_uefi_certs.sh <https://github.com/foundriesio/lmp-tools/blob/master/security/uefi/gen_uefi_certs.sh>`_ script.
+The suggested way to create a custom set of UEFI Secure Boot keys and certificates is via the `lmp-tools gen_uefi_certs.sh <https://github.com/foundriesio/lmp-tools/blob/main/security/uefi/gen_uefi_certs.sh>`_ script.
 
 1. Clone the ``lmp-tools`` repository from GitHub
 

--- a/source/user-guide/container-preloading/container-preloading.rst
+++ b/source/user-guide/container-preloading/container-preloading.rst
@@ -255,4 +255,4 @@ Verify the ``compose-apps-early-start`` application status:
 After the ``compose-apps-early-start`` service has been successfully run, ``docker ps`` will show that the preloaded apps are running.
 
 
-.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master
+.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/main

--- a/source/user-guide/fioctl/index.rst
+++ b/source/user-guide/fioctl/index.rst
@@ -84,7 +84,7 @@ Target metadata can be inspected by using 3 primary commands
            $ fioctl targets list
            VERSION  TAGS    APPS                             HARDWARE IDs
            -------  ----    ----                             ------------
-           1        master  simple-app,netdata               raspberrypi3-64
+           1        main    simple-app,netdata               raspberrypi3-64
            2        devel   mosquitto,simple-app,netdata     raspberrypi3-64
            3        devel   simple-app,netdata,mosquitto     raspberrypi3-64
 
@@ -207,13 +207,13 @@ View Targets
        VERSION  TAGS    APPS        HARDWARE IDs
        -------  ----    ----        ------------
        2        devel               raspberrypi3-64
-       3        master              raspberrypi3-64
-       4        master  shellhttpd  raspberrypi3-64
-       5        master  shellhttpd  raspberrypi3-64
-       6        master              raspberrypi3-64
-       7        master              raspberrypi3-64
-       8        master  httpd       raspberrypi3-64
-       11       master  octofio     raspberrypi3-64
+       3        main                raspberrypi3-64
+       4        main    shellhttpd  raspberrypi3-64
+       5        main    shellhttpd  raspberrypi3-64
+       6        main                raspberrypi3-64
+       7        main                raspberrypi3-64
+       8        main    httpd       raspberrypi3-64
+       11       main    octofio     raspberrypi3-64
 
 List devices
   ``fioctl devices list -f <factory>``
@@ -230,13 +230,13 @@ List devices
 Set device tag
   ``fioctl devices config updates <device_name> --tag <tag>``
     Filter the Targets a device will accept by tag. For example, to move a
-    device from accepting 'devel' builds to 'master' builds. See the
+    device from accepting 'devel' builds to 'main' builds. See the
     :ref:`ref-advanced-tagging` section for more examples.
 
   .. code-block:: console
 
      $ fioctl devices config updates ein --tag devel                                 
-     Changing tag from: master -> devel  
+     Changing tag from: main -> devel  
 
 Set app(s) to be enabled
   ``fioctl devices config updates <device_name> --apps <app_name1>,<app_name2>``

--- a/source/user-guide/foundriesio-rest-api/foundriesio-rest-api.rst
+++ b/source/user-guide/foundriesio-rest-api/foundriesio-rest-api.rst
@@ -132,7 +132,7 @@ Using the terminal, run:
            "meta-subscriber-overrides-sha": "7de1123998c9b362df278132fde8fccb57215647",
            "name": "raspberrypi3-64-lmp",
            "tags": [
-             "master"
+             "main"
            ],
            "targetFormat": "OSTREE",
            "updatedAt": "2021-07-28T20:40:39Z",

--- a/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
+++ b/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
@@ -151,5 +151,5 @@ Check also the file ``/etc/hostname`` to confirm the new hostname.
       
            raspberrypi3-64-b827ebca7875
 
-.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master
-.. _lmp-auto-hostname: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-support/lmp-auto-hostname
+.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/main
+.. _lmp-auto-hostname: https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-support/lmp-auto-hostname

--- a/source/user-guide/lmp-device-auto-register/lmp-device-auto-register.rst
+++ b/source/user-guide/lmp-device-auto-register/lmp-device-auto-register.rst
@@ -180,5 +180,5 @@ Verify the ``lmp-device-auto-register`` application status:
          Process: 774 ExecStart=/usr/bin/lmp-device-auto-register (code=exited, status=0/SUCCESS)
         Main PID: 774 (code=exited, status=0/SUCCESS)
 
-.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/master
-.. _lmp-device-auto-register: https://github.com/foundriesio/meta-lmp/tree/master/meta-lmp-base/recipes-support/lmp-device-auto-register
+.. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/main
+.. _lmp-device-auto-register: https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-support/lmp-device-auto-register

--- a/source/user-guide/mirror-action/mirror-action.rst
+++ b/source/user-guide/mirror-action/mirror-action.rst
@@ -106,22 +106,22 @@ Under ``lmp:`` and ``containers:`` the group ``tagging:`` shows the configured b
 
     lmp:
       tagging:
-        refs/heads/master:
-          - tag: master
+        refs/heads/main:
+          - tag: main
         refs/heads/devel:
           - tag: devel
     ...
     containers:
       tagging:
-        refs/heads/master:
-          - tag: master
+        refs/heads/main:
+          - tag: main
         refs/heads/devel:
           - tag: devel
     ...
 
 Based on the example, FoundriesFactory CI is configured to trigger new builds 
-whenever a new commit is sent on ``master`` or ``devel`` branches. The following 
-commands, guides you to mirror the ``master`` branch.
+whenever a new commit is sent on ``main`` or ``devel`` branches. The following 
+commands, guides you to mirror the ``main`` branch.
 
 .. note::
 
@@ -139,17 +139,17 @@ Clone your GitHub repository and enter its directory:
     git clone https://github.com/<host>/<repo_name>
     cd <repo_name>
 
-Check out the ``master`` branch.
+Check out the ``main`` branch.
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ git checkout master
+    host:~$ git checkout main
 
 In case you don't have a master branch yet, create one:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ git checkout -b master
+    host:~$ git checkout -b main
 
 You must store workflow files in the ``.github/workflows/`` directory of your repository.
 
@@ -178,7 +178,7 @@ Finally, create the file ``mirror.yml`` and make sure you update the ``<FACTORY-
             - uses: actions/checkout@v2
               with:
                 fetch-depth: 0
-            - uses: foundriesio/mirror-action@master
+            - uses: foundriesio/mirror-action@main
               with:
                 REMOTE: "https://source.foundries.io/factories/<FACTORY-NAME>/containers.git"
                 GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}


### PR DESCRIPTION
Instances where master branch should be changed to main were implemented. Not all were directly related to the Fast First Target/customer repos; links and references to meta-lmp were also updated to main.

QA steps: built html and linkcheck. As the focus was on keeping things atomic, linter warnings were ignored, as difficult as it was.

This commit addresses FFTK-2430  
This commit addresses FFTK-860

## Readiness

*   [x] Merge (pending reviews)
*   [ ] Merge after _date or event_
*   [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._  
_You can fill this out after opening the PR. "Did I..."_

*   [ ] Run spelling and grammar check, preferably with linter.
*   [x] Avoid changing any header associated with a link/reference.
*   [ ] Step through instructions (or ask someone to do so).
*   [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
*   [x] Match tone and style of page/section.
*   [x] Run `make linkcheck`.
*   [ ] View HTML in a browser to check rendering.
*   [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
*   [x] follow best practices for commits.
    *   [x] Descriptive title written in the imperative.
    *   [x] Include brief overview of QA steps taken.
    *   [x] Mention any related issues numbers.
    *   [x] End message with sign off/DCO line (`-s, --signoff`).
    *   [x] Sign commit with your gpg key (`-S, --gpg-sign`).
    *   [x] Squash commits if needed.
*   [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._  
_This could include potential issues, rational for approach, etc._