### PR TITLE
Fix broken links in security section

### DIFF
--- a/source/reference-manual/security/cert-rotation.rst
+++ b/source/reference-manual/security/cert-rotation.rst
@@ -47,13 +47,10 @@ The certificate renewal logic uses the EST 7030 `simple re-enrollment`_ process 
 
  * EST Server verifies request, creates a new certificate, and returns it to the device
 
- * The new certificate is valid for `one year`_
+ * The new certificate is valid for one year
 
 .. _simple re-enrollment:
    https://www.rfc-editor.org/rfc/rfc7030.html#section-4.2.2
-
-.. _one year:
-   https://github.com/foundriesio/estserver/blob/1b32b40729c60e8dfa21155dd1d31135244e56c1/service.go#L210
 
 Tracking Progress
 -----------------

--- a/source/reference-manual/security/imx-generic-custom-keys.rst
+++ b/source/reference-manual/security/imx-generic-custom-keys.rst
@@ -101,4 +101,4 @@ close the board, respectively.
   after understanding its critical implications.
 
 .. _i.MX Secure Boot on HABv4 Supported Devices: https://www.nxp.com/webapp/Download?colCode=AN4581&location=null
-.. _Generating a fast authentication PKI tree: https://github.com/nxp-imx/uboot-imx/blob/lf_v2022.04/doc/imx/habv4/introduction_habv4.txt#L193
+.. _Generating a fast authentication PKI tree: https://github.com/nxp-imx/uboot-imx/blob/lf_v2022.04/doc/imx/habv4/introduction_habv4.txt

--- a/source/reference-manual/security/secure-boot-uefi.rst
+++ b/source/reference-manual/security/secure-boot-uefi.rst
@@ -82,7 +82,7 @@ Once PK is added by the user, most UEFI implementations move the active mode fro
 Creating UEFI Secure Boot Keys
 -----------------------------------
 
-The suggested way to create a custom set of UEFI Secure Boot keys and certificates is via the `lmp-tools gen_uefi_certs.sh <https://github.com/foundriesio/lmp-tools/blob/main/security/uefi/gen_uefi_certs.sh>`_ script.
+The suggested way to create a custom set of UEFI Secure Boot keys and certificates is via the `lmp-tools gen_uefi_certs.sh <https://github.com/foundriesio/lmp-tools/blob/master/security/uefi/gen_uefi_certs.sh>`_ script.
 
 1. Clone the ``lmp-tools`` repository from GitHub
 


### PR DESCRIPTION
Linkcheck encountered issues with some links. In two instances it was a simple 404 issue with a changed location of content. In the other the link functions in the browser, however linkcheck seemed to have issue with GitHub links linking to specific line numbers.

For the link in `cert-rotation.rst`, it was simply removed, as it did not feel necessary.

QA Steps: ran linkcheck

No related issues/tickets, minor quick fix.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Simple fixes to some broken links

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
