### PR TITLE
Add link to customizing platform at end of gs

### DIFF
--- a/source/getting-started/building-deploying-app/index.rst
+++ b/source/getting-started/building-deploying-app/index.rst
@@ -104,6 +104,8 @@ You can also test the container from an external device connected to the same ne
 
      Hello world
 
-You can follow a more detailed documentation by following the next section **Tutorials** starting with :ref:`tutorial-gs-with-docker`
+You can get a more detailed guide by following the next section, **Tutorials**, starting with :ref:`tutorial-gs-with-docker`.
 
-
+.. seealso::
+   If you would like to learn about how to customize the platform,
+   checkout both our :ref:`tutorial <tutorial-customizing-the-platform>`, and the user guide on :ref:`lmp-customization`.


### PR DESCRIPTION
A `seealso` admonition was added to the end of the getting started guide's build and deploy section.

QA steps: Ran linter, linkcheck, and examined html. No issues found.

This commit addresses FFTK-2620.

## Readiness

*   [x] Merge (pending reviews)
*   [ ] Merge after _date or event_
*   [ ] Draft

## Overview

Addresses feedback from Slack discussion. It also seems like useful info to point to at the end of getting started, as it may be the next step for some.

## Checklist

_Optional. Add a 'x' to steps taken._  
_You can fill this out after opening the PR. "Did I..."_

*   [x] Run spelling and grammar check, preferably with linter.
*   [x] Avoid changing any header associated with a link/reference.
*   [x] Step through instructions (or ask someone to do so).
*   [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
*   [x] Match tone and style of page/section.
*   [x] Run `make linkcheck`.
*   [x] View HTML in a browser to check rendering.
*   [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
*   [x] follow best practices for commits.
    *   [x] Descriptive title written in the imperative.
    *   [x] Include brief overview of QA steps taken.
    *   [x] Mention any related issues numbers.
    *   [x] End message with sign off/DCO line (`-s, --signoff`).
    *   [x] Sign commit with your gpg key (`-S, --gpg-sign`).
    *   [x] Squash commits if needed.
*   [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._  
_This could include potential issues, rational for approach, etc._