### PR TITLE
Fix incorrect internal reference link

### DIFF
--- a/source/user-guide/lmp-customization/lmp-customization.rst
+++ b/source/user-guide/lmp-customization/lmp-customization.rst
@@ -59,7 +59,7 @@ Configure to only load a natively supported kernel module, such as ``i2c-dev``, 
 .. note::
     To autoload an out of tree kernel module, please refer to :ref:`ref-pg-new-driver`.
 
-.. _ref-faq-service:
+.. _ref-troubleshooting_systemd-service:
 
 Adding a new Systemd Startup Service
 -------------------------------------
@@ -338,7 +338,7 @@ Anything created under ``/var`` gets removed when creating the OSTree deployment
 An example of using `tmpfiles`_ to create a directory under ``/var`` can be found in meta-lmp `collectd.bbappend`_, where `tmpfiles.conf`_ shows the directory to be created.
 
 .. tip::
-   Files can also be created dynamically using a runtime service. See how to add a :ref:`Custom Systemd Service<ref-faq-service>`.
+   Files can also be created dynamically using a runtime service. See how to add a :ref:`Custom Systemd Service<ref-troubleshooting_systemd-service>`.
 
 .. _tmpfiles:
    https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html

--- a/source/user-guide/troubleshooting/troubleshooting.rst
+++ b/source/user-guide/troubleshooting/troubleshooting.rst
@@ -454,8 +454,6 @@ If a bind mount destination does not exist, Docker will create the endpoint as a
 
 The Docker documentation on `containers and bind mounting <https://docs.docker.com/storage/bind-mounts/>`_ is a good place to start if you wish to learn more about this.
 
-.. _ref-troubleshooting_systemd-service:
-
 NXP SE05X Secure Element and PKCS#11 Trusted Application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Added the reference to the correct location, removed from the incorrect.

QA Steps: Rendered into html and checked the new link locally.

No issues to link, quick fix.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
