### PR TITLE
README: Add graphviz installation as required package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This will set up the necessary environment for sphinx packages and place them he
 
 ```bash
 
-$ sudo apt-get install python3 python3-virtualenv
+$ sudo apt-get install graphviz python3 python3-virtualenv
 $ virtualenv -p /usr/bin/python3 venv
 $ . ./venv/bin/activate
 $ pip install -r requirements.txt


### PR DESCRIPTION
It is only updating the README to include the graphviz dependency.

I've tried to find a package to add via requirements.txt, but I could not find it _easily_. So let's keep the same logic used on the server builds and use the external graphviz.