### PR TITLE
Add info on Account Roles and device management

### DIFF
--- a/source/user-guide/account-management/account-roles.rst
+++ b/source/user-guide/account-management/account-roles.rst
@@ -21,11 +21,12 @@ There are four roles available. The two core roles being:
   - add and update members
   - manage teams
   - manage the Factory subscription plan
+  - register, delete, and rename all devices
   - manage the Factory's Public Key Infrastructure (PKI) and create Waves.
   
 The remaining two each get a subset of the **Owner** permissions.
 
-* **Admin**: Add and update members, :ref:`manage teams <ref-team-based-access>`, manage PKI, and create Waves.
+* **Admin**: Add and update members, :ref:`manage teams <ref-team-based-access>` and device groups, manage PKI, and create Waves.
 * **Accounting** limited to managing the :ref:`Factory plan <ref-subscription-and-billing>`.
 
 .. tip::
@@ -33,6 +34,10 @@ The remaining two each get a subset of the **Owner** permissions.
     For example, more than one member can have the **Owner** role.
     However, a single member has only one role at a time.
 
+By default, users can access device groups they created, the devices in them, and the devices they own.
+
+.. seealso::
+   :ref:`Team Based Factory Access <ref-team-based-access>` for permissions related to development and device management.
 
 How it Works: Walk Through
 --------------------------
@@ -56,7 +61,5 @@ and assigns the desired role:
    :align: center
    :alt: UI, changing member role
 
-From here roles can be changed anytime.
+From here, roles can be changed anytime.
 
-.. seealso::
-   :ref:`Team Based Factory Access <ref-team-based-access>` for permissions related to development and device management.


### PR DESCRIPTION
Information on Account Roles and how it relates to device management was added, based of of existing information from the Team based access page.

The information will need to be verified.

QA steps: Ran linter. Checked rendered output.

This commit addresses FFTK-2603

## Readiness

*   [x] Merge (pending reviews)
*   [ ] Merge after _date or event_
*   [ ] Draft

## Overview

_This is a basic attempt at addressing the issue, we may want to make additional changes._

## Checklist

_Optional. Add a 'x' to steps taken._  
_You can fill this out after opening the PR. "Did I..."_

*   [x] Run spelling and grammar check, preferably with linter.
*   [x] Avoid changing any header associated with a link/reference.
*   [ ] Step through instructions (or ask someone to do so).
*   [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
*   [x] Match tone and style of page/section.
*   [x] Run `make linkcheck`.
*   [x] View HTML in a browser to check rendering.
*   [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
*   [x] follow best practices for commits.
    *   [x] Descriptive title written in the imperative.
    *   [x] Include brief overview of QA steps taken.
    *   [x] Mention any related issues numbers.
    *   [x] End message with sign off/DCO line (`-s, --signoff`).
    *   [x] Sign commit with your gpg key (`-S, --gpg-sign`).
    *   [x] Squash commits if needed.
*   [x] Request PR review by a technical writer and at least one peer.

## Comments

_This should be verified to make sure all the information is correct._