### PR TITLE
rm: security: The variable UBOOT_SIGN_ENABLE from factory is deprecated

### DIFF
--- a/source/reference-manual/security/secure-machines.rst
+++ b/source/reference-manual/security/secure-machines.rst
@@ -60,7 +60,6 @@ configuration::
         DISTRO: lmp-mfgtool
         IMAGE: mfgtool-files
         EXTRA_ARTIFACTS: mfgtool-files.tar.gz
-        UBOOT_SIGN_ENABLE: "1"
 
 How to use
 ----------


### PR DESCRIPTION
The variable is deprecated since:
https://github.com/foundriesio/ci-scripts/pull/306