### PR TITLE
Fix indent on factory definition page

### DIFF
--- a/source/reference-manual/factory/factory-definition.rst
+++ b/source/reference-manual/factory/factory-definition.rst
@@ -21,7 +21,7 @@ Configures the users who receive an email with the build notification.
          notify:
            email:
              users: foo@foo.com,bar@bar.com
-           failures_only: false
+             failures_only: false
 
 notify:
  email:


### PR DESCRIPTION
The `failures_only` param option was idented to belong to `email`.

QA: Checked rendered doc, no issues.

No issues to link to, minor issue and fix.

## Readiness

*   [x] Merge (pending reviews)
*   [ ] Merge after _date or event_
*   [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._  
_You can fill this out after opening the PR. "Did I..."_

*   [ ] Run spelling and grammar check, preferably with linter.
*   [x] Avoid changing any header associated with a link/reference.
*   [ ] Step through instructions (or ask someone to do so).
*   [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
*   [ ] Match tone and style of page/section.
*   [ ] Run `make linkcheck`.
*   [x] View HTML in a browser to check rendering.
*   [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
*   [x] follow best practices for commits.
    *   [x] Descriptive title written in the imperative.
    *   [x] Include brief overview of QA steps taken.
    *   [x] Mention any related issues numbers.
    *   [x] End message with sign off/DCO line (`-s, --signoff`).
    *   [x] Sign commit with your gpg key (`-S, --gpg-sign`).
    *   [x] Squash commits if needed.
*   [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._  
_This could include potential issues, rational for approach, etc._