### PR TITLE
rm: boards: Use compressed image with mfgtool files

### DIFF
--- a/source/reference-manual/boards/imx-common-board.inc
+++ b/source/reference-manual/boards/imx-common-board.inc
@@ -23,15 +23,14 @@ Factory.
         |     ``u-boot-<machine_name>.itb``
         |     ``imx-boot-<machine_name>``
 
+          .. note::
+            The compressed image (``.wic.gz``) is used since LmP **v92**. Before it the scripts
+            require a compressed file image (``.wic``).
+
           .. figure:: /_static/boards/generic-steps-2.png
             :width: 769
             :align: center
 
-#. Extract the file ``lmp-factory-image-<machine_name>.wic.gz``:
-
-     .. parsed-literal::
-
-      gunzip lmp-factory-image-|machine_name|.wic.gz
 
 #. Download and extract the file ``mfgtool-files-<machine_name>.tar.gz``:
 

--- a/source/reference-manual/boards/imx6ul.rst
+++ b/source/reference-manual/boards/imx6ul.rst
@@ -46,7 +46,7 @@ i.MX 6UL Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx6ulevk.wic
+          ├── lmp-factory-image-imx6ulevk.wic.gz
           ├── u-boot-imx6ulevk.itb
           ├── sit-imx6ulevk.bin
           ├── SPL-imx6ulevk

--- a/source/reference-manual/boards/imx6ull.rst
+++ b/source/reference-manual/boards/imx6ull.rst
@@ -45,7 +45,7 @@ i.MX 6ULL Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx6ullevk.wic
+          ├── lmp-factory-image-imx6ullevk.wic.gz
           ├── u-boot-imx6ullevk.itb
           ├── sit-imx6ullevk.bin
           ├── SPL-imx6ullevk

--- a/source/reference-manual/boards/imx8mm.rst
+++ b/source/reference-manual/boards/imx8mm.rst
@@ -47,7 +47,7 @@ i.MX 8M Mini Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx8mm-lpddr4-evk.wic
+          ├── lmp-factory-image-imx8mm-lpddr4-evk.wic.gz
           ├── u-boot-imx8mm-lpddr4-evk.itb
           ├── sit-imx8mm-lpddr4-evk.bin
           ├── imx-boot-imx8mm-lpddr4-evk

--- a/source/reference-manual/boards/imx8mn.rst
+++ b/source/reference-manual/boards/imx8mn.rst
@@ -46,7 +46,7 @@ i.MX 8M Nano Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx8mn-ddr4-evk.wic
+          ├── lmp-factory-image-imx8mn-ddr4-evk.wic.gz
           ├── u-boot-imx8mn-ddr4-evk.itb
           ├── sit-imx8mn-ddr4-evk.bin
           ├── imx-boot-imx8mn-ddr4-evk

--- a/source/reference-manual/boards/imx8mp.rst
+++ b/source/reference-manual/boards/imx8mp.rst
@@ -48,7 +48,7 @@ i.MX 8M Plus Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx8mp-lpddr4-evk.wic
+          ├── lmp-factory-image-imx8mp-lpddr4-evk.wic.gz
           ├── u-boot-imx8mp-lpddr4-evk.itb
           ├── sit-imx8mp-lpddr4-evk.bin
           ├── imx-boot-imx8mp-lpddr4-evk

--- a/source/reference-manual/boards/imx8mq.rst
+++ b/source/reference-manual/boards/imx8mq.rst
@@ -45,7 +45,7 @@ i.MX 8M Quad Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx8mq-evk.wic
+          ├── lmp-factory-image-imx8mq-evk.wic.gz
           ├── u-boot-imx8mq-evk.itb
           ├── sit-imx8mq-evk.bin
           ├── imx-boot-imx8mq-evk or imx-boot-imx8mq-evk-nohdmi

--- a/source/reference-manual/boards/imx8ulpevk.rst
+++ b/source/reference-manual/boards/imx8ulpevk.rst
@@ -47,7 +47,7 @@ i.MX 8 ULP Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx8ulp-lpddr4-evk.wic
+          ├── lmp-factory-image-imx8ulp-lpddr4-evk.wic.gz
           ├── u-boot-imx8ulp-lpddr4-evk.itb
           ├── imx-boot-imx8ulp-lpddr4-evk
           └── mfgtool-files-imx8ulp-lpddr4-evk

--- a/source/reference-manual/boards/imx93evk.rst
+++ b/source/reference-manual/boards/imx93evk.rst
@@ -48,7 +48,7 @@ i.MX 93 Evaluation Kit
 
 .. |imx_file_list| prompt:: text
 
-          ├── lmp-factory-image-imx93-11x11-lpddr4x-evk.wic
+          ├── lmp-factory-image-imx93-11x11-lpddr4x-evk.wic.gz
           ├── u-boot-imx93-11x11-lpddr4x-evk.itb
           ├── imx-boot-imx93-11x11-lpddr4x-evk
           └── mfgtool-files-imx93-11x11-lpddr4x-evk


### PR DESCRIPTION
Since https://github.com/foundriesio/meta-lmp/pull/1279 we are using compressed image in the uuu script for full image flashing.

## Readiness

To be merged after  https://github.com/foundriesio/meta-lmp/pull/1279 is merged


## Checklist

* [x] View HTML in a browser to check rendering.

