### PR TITLE
Add reference to managing devices

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -394,7 +394,7 @@ redirects = {
      "customer-factory/writing-images": "../getting-started/flash-device/index.html",
      "customer-factory/updating-the-core": "../reference-manual/linux/linux-update.html",
      "customer-factory/source-code": "../tutorials/customizing-the-platform/customizing-the-platform.html",
-     "customer-factory/managing": "../user-guide/account-management/account-management.html",
+     "customer-factory/managing": "../getting-started/register-device/index.html",
      "customer-factory/getting-started": "../getting-started/signup/index.html",
      "customer-factory/first-boot": "../getting-started/flash-device/index.html#booting-and-connecting-to-the-network",
      "customer-factory/extending": "../reference-manual/linux/linux-extending.html",

--- a/source/getting-started/register-device/index.rst
+++ b/source/getting-started/register-device/index.rst
@@ -3,9 +3,9 @@
 Registering Your Device
 =======================
 
-Your Linux® microPlatform (LmP) image includes the ``lmp-device-register`` tool that registers your device via the Foundries.io™ REST API.
+Your Linux® microPlatform (LmP) image includes the ``lmp-device-register`` tool that manages device registration for your device via the Foundries.io™ REST API.
 
-1. Run this command from the device console to register it with your Factory:
+1. To register a device with your Factory, run the following from the device console:
 
  .. prompt:: bash device:~$, auto
 
@@ -14,11 +14,10 @@ Your Linux® microPlatform (LmP) image includes the ``lmp-device-register`` tool
 .. note::
     The parameter ``-f <factory>`` is only needed for the first target.
 
-2. You will be prompted by ``lmp-device-register`` to `complete a challenge <https://www.oauth.com/oauth2-servers/device-flow/>`_ with our API. Follow the instructions on the promped message:
+2. You will be prompted by ``lmp-device-register`` to `complete a challenge <https://www.oauth.com/oauth2-servers/device-flow/>`_ with our API.
+   Follow the instruction prompts:
 
    .. highlight:: none
-
-   **Example Output**:
 
    .. prompt:: text
 
@@ -44,5 +43,9 @@ Your Linux® microPlatform (LmP) image includes the ``lmp-device-register`` tool
 
 .. note::
 
-    **By default**, after registration devices will run **all** applications that are available in the latest Target. This behavior can be changed by enabling only specific applications.
+    After registration devices will run **all** applications that are available in the latest Target.
+    This default behavior can be changed by enabling only specific applications.
     Read :ref:`ug-fioctl-enable-apps` to learn how.
+
+.. seealso::
+   :ref:`Team Based Factory Access <ref-team-based-access>` for permissions related to device management.


### PR DESCRIPTION
Updated getting-started/registering-device to include "managing" language to improve findability. Older (v73) docs had "Managing" page, redirect now goes to the getting started page. With same info.

Small style changes also applied to the page.

QA Steps: Ran linter, linkcheck, and checked html in browser.

No issues to link, small fix following Slack discussion.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
