### PR TITLE
(QEMU) Clarification on ENV VAR Usage

### DIFF
--- a/source/reference-manual/qemu/qemu-instructions.template
+++ b/source/reference-manual/qemu/qemu-instructions.template
@@ -21,16 +21,16 @@ Booting in QEMU
 
 .. important:: These instructions require QEMU 5.2 or later.
 
+#. List available Targets and decide on which to boot::
+
+     fioctl targets list
+
 .. note::
-	Make sure to set the FIOCTL_FACTORY environment variable:
+    Make sure to set the FIOCTL_FACTORY environment variable so that you can list the target of the specified factory:
 
     .. parsed-literal::
 
         export FIOCTL_FACTORY=<factory>
-
-#. List available Targets and decide on which to boot::
-
-     fioctl targets list
 
 #. Make a directory for the artifacts and ``cd`` into it:
 


### PR DESCRIPTION
## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

The note provided before the command might lead users to believe that the ENV VAR will automatically be utilized by QEMU during its execution. This can be misleading, especially for those unfamiliar with QEMU or the outlined solution. Personally, the necessity of exporting this variable wasn't clear to me until I reviewed the 'targets' section.

So I would like to suggest the following changes:

**Before this PR:**

![Screenshot 2023-09-20 at 16 41 18](https://github.com/foundriesio/docs/assets/7708031/daa5a169-d532-44af-b7c4-0fac3dbeeabd)

**Suggested changes in this PR**
![Screenshot 2023-09-20 at 16 32 27](https://github.com/foundriesio/docs/assets/7708031/1d517ad8-d661-48e2-9527-0f9727ff38ee)


## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
