### PR TITLE
(QEMU run) fix nit - remove line added my mistake into the example

### DIFF
--- a/source/reference-manual/qemu/arm64.rst
+++ b/source/reference-manual/qemu/arm64.rst
@@ -40,7 +40,6 @@ QEMU CLI
         -device virtio-gpu-pci \
         -display default,show-cursor=on \
         -drive file=QEMU_EFI.fd,format=raw,readonly=on,if=pflash \
-        -drive file=QEMU_VARS.fd,format=raw,if=pflash \   # Here's the added line
         -serial mon:stdio -serial null
 
 .. include:: qemu-ssh.template


### PR DESCRIPTION
## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

The line `-drive file=QEMU_VARS.fd,format=raw,if=pflash \   # Here's the added line` should not be added because I am not using it to run


* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
