### PR TITLE
el2g: add documentation for GENERIC_KEYPAIRS

### DIFF
--- a/source/user-guide/el2g.rst
+++ b/source/user-guide/el2g.rst
@@ -234,8 +234,9 @@ EdgeLock 2GO Concepts
 Installing Additional Secure Objects
 ------------------------------------
 
-Any additional Secure Objects that are defined in EdgeLock 2GO and provisioned into the secure element when the device registers.
-Additionally, keypairs and certificates are loaded into PKCS#11 so they are accessible to e.g. OpenSSL.
+Additional Secure Objects can be defined in EdgeLock 2GO through the API.
+These objects are provisioned into the Secure Element when the device registers.
+On top of this, keypairs and certificates are loaded into PKCS#11 so they are accessible, e.g., OpenSSL.
 The convention is that the keypair secure object has an even-numbered OID (e.g. 0x10000010) and the corresponding certificate has an OID one higher (e.g. 0x10000011).
 To enable automatic loading of the keypair and certificate, the ``GENERIC_KEYPAIRS`` variable must be set in ``/etc/default/lmp-el2go-auto-register`` e.g.,
 

--- a/source/user-guide/el2g.rst
+++ b/source/user-guide/el2g.rst
@@ -231,6 +231,21 @@ EdgeLock 2GO Concepts
  * **Subdomain** — Every EdgeLock 2GO account has a "device-link" subdomain that a device's ``nxp_iot_agent_demo`` binary connects to.
    This is the service where secure objects will be exchanged.
 
+Installing additional Secure Objects
+------------------------------------
+
+Any additional Secure Objects that are defined in EdgeLock 2GO and provisioned into the secure element when the device registers.
+Additionally, keypairs and certificates are loaded into PKCS#11 so they are accessible to e.g. OpenSSL.
+The convention is that the keypair secure object has an even-numbered OID (e.g. 0x10000010) and the corresponding certificate has an OID one higher (e.g. 0x10000011).
+To enable automatic loading of the keypair and certificate, the `GENERIC_KEYPAIRS` variable must be set in `/etc/default/lmp-el2go-auto-register`. E.g.
+
+  # recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/default.env
+  REPOID=<YOUR ID FROM fioctl factories>
+  GENERIC_KEYPAIRS="0x10000010"
+
+`GENERIC_KEYPAIRS` defaults to 0X83000044 which is the OID used by AWS IoT.
+
+
 Further Details
 ---------------
 

--- a/source/user-guide/el2g.rst
+++ b/source/user-guide/el2g.rst
@@ -231,20 +231,20 @@ EdgeLock 2GO Concepts
  * **Subdomain** — Every EdgeLock 2GO account has a "device-link" subdomain that a device's ``nxp_iot_agent_demo`` binary connects to.
    This is the service where secure objects will be exchanged.
 
-Installing additional Secure Objects
+Installing Additional Secure Objects
 ------------------------------------
 
 Any additional Secure Objects that are defined in EdgeLock 2GO and provisioned into the secure element when the device registers.
 Additionally, keypairs and certificates are loaded into PKCS#11 so they are accessible to e.g. OpenSSL.
 The convention is that the keypair secure object has an even-numbered OID (e.g. 0x10000010) and the corresponding certificate has an OID one higher (e.g. 0x10000011).
-To enable automatic loading of the keypair and certificate, the `GENERIC_KEYPAIRS` variable must be set in `/etc/default/lmp-el2go-auto-register`. E.g.
+To enable automatic loading of the keypair and certificate, the ``GENERIC_KEYPAIRS`` variable must be set in ``/etc/default/lmp-el2go-auto-register`` e.g.,
 
+::
   # recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/default.env
   REPOID=<YOUR ID FROM fioctl factories>
   GENERIC_KEYPAIRS="0x10000010"
 
-`GENERIC_KEYPAIRS` defaults to 0X83000044 which is the OID used by AWS IoT.
-
+``GENERIC_KEYPAIRS`` defaults to 0X83000044 which is the OID used by AWS IoT.
 
 Further Details
 ---------------


### PR DESCRIPTION
lmp-el2go-auto-register was extended with support for generic keypairs in PR https://github.com/foundriesio/meta-lmp/pull/1307. Document this new feature, in particular that `GENERIC_KEYPAIRS` has to be set in `/etc/default/lmp-el2go-auto-register`.

## Readiness

* [ ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
