### PR TITLE
doc: suggestion: Clarify Manufacturing Process for Device Registration

### DIFF
--- a/source/reference-manual/security/factory-registration-ref.rst
+++ b/source/reference-manual/security/factory-registration-ref.rst
@@ -3,18 +3,25 @@
 Manufacturing Process for Device Registration
 =============================================
 
-lmp-device-auto-register works great when run manually and can be configured
+Device registration is an important step to ensure that only trusted and authorized devices can
+connect to the Foundries.io™ infrastructure. ``lmp-device-auto-register`` works well when run manually, and can be configured
 to auto register devices in **CI**
 :ref:`builds <ug-lmp-device-auto-register>`. However,
 a different process is required for provisioning production devices.
 The key to production provisioning lies in owning the
-:ref:`device gateway PKI <ref-device-gateway>`. Once a customer has
+:ref:`device gateway PKI <ref-device-gateway>`.
+
+The :ref:`device gateway PKI <ref-device-gateway>` serves as the trust anchor for all device communications.
+When a device tries to connect to the Foundries.io gateway, it presents a TLS certificate.
+Once a customer has
 control of their PKI, they can create client TLS certificates for
 devices that will be trusted by the Foundries.io device gateway.
 
 Customers all have unique requirements, so Foundries.io created a
 `reference implementation`_ that customers can fork and modify to
-their liking. Here are some common ways to use this reference.
+their liking. By using this example, customers can authenticate
+and register devices, granting them the necessary certificates to be
+trusted by the Foundries.io gateway. Here are some common ways to use this reference.
 
 .. _ref-fully-detached:
 


### PR DESCRIPTION
Improve documentation to help users better understand the purpose and relationship between the `factory-registration-ref` and the device gateway. (`to just try make it a little easier to connect the dots here`) 


Signed-off-by: Camila Macedo <camila.macedo@foundries.io>

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
