### PR TITLE
Replace gedit references with vi for broader OS compatibility

### DIFF
--- a/source/tutorials/configuring-and-sharing-volumes/copy-configuration-file-using-dockerfile.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/copy-configuration-file-using-dockerfile.rst
@@ -24,7 +24,7 @@ Edit the ``Dockerfile`` to create the ``shellhttpd`` folder and copy ``shellhttp
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/Dockerfile
+    host:~$ vi shellhttpd/Dockerfile
 
 ::
 

--- a/source/tutorials/configuring-and-sharing-volumes/modify-shellhttpd-container.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/modify-shellhttpd-container.rst
@@ -12,7 +12,7 @@ Edit ``httpd.sh`` as below:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/httpd.sh
+    host:~$ vi shellhttpd/httpd.sh
 
 .. prompt:: shell
 

--- a/source/tutorials/configuring-and-sharing-volumes/sharing-folder.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/sharing-folder.rst
@@ -14,7 +14,7 @@ Edit ``docker-compose.yml``, adding the ``volumes`` stanza:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 ::
 

--- a/source/tutorials/configuring-and-sharing-volumes/update-shellhttpd-application.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/update-shellhttpd-application.rst
@@ -12,7 +12,7 @@ Start by removing ``shellhttpd.conf`` from the ``Dockerfile`` to simplify your a
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/Dockerfile
+    host:~$ vi shellhttpd/Dockerfile
 
 ::
 
@@ -26,7 +26,7 @@ Edit ``docker-compose.yml`` and change the ``volumes`` stanza to share the ``/va
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 ::
 

--- a/source/tutorials/customizing-the-platform/enabling-recipe.rst
+++ b/source/tutorials/customizing-the-platform/enabling-recipe.rst
@@ -22,7 +22,7 @@ Edit ``recipes-samples/images/lmp-factory-image.bb`` and append ``CORE_IMAGE_BAS
 .. prompt:: bash host:~$, auto
 
     host:~$ cd ..
-    host:~$ gedit recipes-samples/images/lmp-factory-image.bb
+    host:~$ vi recipes-samples/images/lmp-factory-image.bb
 
 .. prompt:: text
 

--- a/source/tutorials/getting-started-with-docker/extra-commands.rst
+++ b/source/tutorials/getting-started-with-docker/extra-commands.rst
@@ -143,7 +143,7 @@ Using the text editor of your choice, change ``OK`` to ``FoundriesFactory``, the
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit httpd.sh
+    host:~$ vi httpd.sh
 
 **httpd.sh**:
 

--- a/source/tutorials/getting-started-with-docker/gs-docker-compose.rst
+++ b/source/tutorials/getting-started-with-docker/gs-docker-compose.rst
@@ -47,7 +47,7 @@ As you are still developing locally, edit the image parameter to use the image a
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit docker-compose.yml
+    host:~$ vi docker-compose.yml
 
 **docker-compose.yml**:
 

--- a/source/tutorials/working-with-tags/adapting-shellhttpd.rst
+++ b/source/tutorials/working-with-tags/adapting-shellhttpd.rst
@@ -18,7 +18,7 @@ Edit ``httpd.sh`` according to the example below:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/httpd.sh
+    host:~$ vi shellhttpd/httpd.sh
 
 .. prompt:: text
 
@@ -38,7 +38,7 @@ Edit the file ``Dockerfile`` according to the example below:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/Dockerfile
+    host:~$ vi shellhttpd/Dockerfile
 
 .. prompt:: text
 
@@ -52,7 +52,7 @@ Edit the file ``docker-compose.yml`` according to the example below:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 .. prompt:: text
 

--- a/source/tutorials/working-with-tags/creating-targets.rst
+++ b/source/tutorials/working-with-tags/creating-targets.rst
@@ -17,7 +17,7 @@ Edit ``docker-compose.yml``:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 .. prompt:: text
 
@@ -53,7 +53,7 @@ Edit ``docker-compose.yml``:
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 .. prompt:: text
 
@@ -85,7 +85,7 @@ Keep watching your jobs on https://app.foundries.io and once it finishes, change
 
 .. prompt:: bash host:~$, auto
 
-    host:~$ gedit shellhttpd/docker-compose.yml
+    host:~$ vi shellhttpd/docker-compose.yml
 
 **shellhttpd/docker-compose.yml**:
 

--- a/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
+++ b/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
@@ -84,7 +84,7 @@ Select the Serial or MAC tab below, according to your needs.
       
       .. prompt:: bash host:~$, auto
       
-          host:~$ gedit recipes-samples/images/lmp-factory-image.bb
+          host:~$ vi recipes-samples/images/lmp-factory-image.bb
       
       ::
       

--- a/source/user-guide/submodule/submodule.rst
+++ b/source/user-guide/submodule/submodule.rst
@@ -236,7 +236,7 @@ Follow the example below and make sure you update ``<FACTORY_NAME>`` with your F
 
     host:~$ cd myapp/
     host:~$ mkdir -p .github/workflows/ 
-    host:~$ gedit .github/workflows/source-fio-update.yml
+    host:~$ vi .github/workflows/source-fio-update.yml
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Updated the documentation to reference vi instead of gedit for text editing steps. This change ensures broader compatibility across various Unix-like operating systems and offers a more universally available option for readers

Signed-off-by: Camila Macedo <camila.macedo@foundries.io>

## Readiness

* [ ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
