### PR TITLE
Remove mention of devel branch from tutorial

### DIFF
--- a/source/tutorials/customizing-the-platform/commit-and-push-recipe.rst
+++ b/source/tutorials/customizing-the-platform/commit-and-push-recipe.rst
@@ -62,7 +62,7 @@ Push:
 
 Go to https://app.foundries.io, select your Factory and click on :guilabel:`Targets`:
 
-The latest **Target** named :guilabel:`platform-devel` should be the CI job you just created.
+The latest **Target** named :guilabel:`platform-main` should be the CI job you just created.
 
 .. note::
 


### PR DESCRIPTION
A mention of 'platform-devel' found in the 'customizing the platform' tutorial was replaced with 'platform-main'.

Grep'd all the tutorial for any other mentions where *not appropriate*.

No QA steps performed.

No issues to link, minor fix.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
