### PR TITLE
rm: Fix lsusb command in some NXP boards flashing instruction

### DIFF
--- a/source/reference-manual/boards/imx8mm.rst
+++ b/source/reference-manual/boards/imx8mm.rst
@@ -22,8 +22,8 @@ i.MX 8M Mini Evaluation Kit
 
 .. |imx_lsusb| prompt:: bash $, auto
 
-     lsusb | grep NXP
-     Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+     $ lsusb | grep NXP
+       Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
 .. |image_board_top| image:: /_static/boards/imx8mmevk.png
      :width: 600

--- a/source/reference-manual/boards/imx8mn.rst
+++ b/source/reference-manual/boards/imx8mn.rst
@@ -22,8 +22,8 @@ i.MX 8M Nano Evaluation Kit
 
 .. |imx_lsusb| prompt:: bash $, auto
 
-     lsusb | grep NXP
-     Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+     $ lsusb | grep NXP
+       Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
 .. |image_board_top| image:: /_static/boards/imx8mn-ddr4-evk.png
      :width: 600

--- a/source/reference-manual/boards/imx8mp.rst
+++ b/source/reference-manual/boards/imx8mp.rst
@@ -23,7 +23,7 @@ i.MX 8M Plus Evaluation Kit
 .. |imx_lsusb| prompt:: bash $, auto
 
      $ lsusb | grep NXP
-     Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+       Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
 .. |image_board_top| image:: /_static/boards/imx8mp-lpddr4-evk.png
      :width: 600

--- a/source/reference-manual/boards/imx8mq.rst
+++ b/source/reference-manual/boards/imx8mq.rst
@@ -23,7 +23,7 @@ i.MX 8M Quad Evaluation Kit
 .. |imx_lsusb| prompt:: bash $, auto
 
            $ lsusb | grep NXP
-           Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+             Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
 .. |image_board_top| image:: /_static/boards/imx8mqevk.png
      :width: 600

--- a/source/reference-manual/boards/imx8ulpevk.rst
+++ b/source/reference-manual/boards/imx8ulpevk.rst
@@ -23,7 +23,7 @@ i.MX 8 ULP Evaluation Kit
 .. |imx_lsusb| prompt:: bash $, auto
 
            $ lsusb | grep NXP
-           Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+             Bus 001 Device 023: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 
 .. |image_board_top| image:: /_static/boards/imx8ulp-lpddr4-evk.png
      :width: 600


### PR DESCRIPTION
In some cases, the command itself was missing the first letter on the rendered html ("susb" instead of "lsusb"). In others, the command output was missing the first letter ("us 002 Device 052..." instead of "Bus 002 Device 052...").

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

The instructions for flashing some NXP boards in the rendered HTMLs where missing the first char in some cases. This PR fixes it.

I've verified the generated HTMLs and grepped for all cases where this was happening, fixing them all.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments


