### PR TITLE
Fix cert-rotation page name duplication

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -336,6 +336,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # Config for sphinx-reredirects, maps source: target, target path is relative to source.
 # TODO: troubleshooting sections redirecting to lmp-customization do not appear to be functional
 redirects = {
+     "user-guide/cert-rotation": "rotating-cert.html",
      "reference-manual/docker/compose-apps": "../../user-guide/containers-and-docker/compose-apps.html",
      "reference-manual/docker/configure-docker-helper": "../../user-guide/containers-and-docker/configure-docker-helper.html",
      "reference-manual/docker/containers": "../../user-guide/containers-and-docker/containers.html",

--- a/source/index.rst
+++ b/source/index.rst
@@ -48,7 +48,7 @@ OE/Yocto Project, the Linux microPlatform™ and Docker®.
    user-guide/submodule/submodule
    user-guide/custom-sota-client
    user-guide/fioctl/index
-   user-guide/cert-rotation
+   user-guide/rotating-cert
    user-guide/device-gateway-pki/device-gateway-pki
    user-guide/offline-update/offline-update
    user-guide/el2g

--- a/source/user-guide/rotating-cert.rst
+++ b/source/user-guide/rotating-cert.rst
@@ -1,6 +1,6 @@
 .. _ref-cert-rotation-ug:
 
-Device Certificate Rotation
+Rotating Device Certificate 
 ===========================
 
 The :ref:`Device Certificate Rotation <ref-cert-rotation>` reference manual describes core concepts and functions of certificate rotation.


### PR DESCRIPTION
The cert rotation page in the user-guide, `cert-rotation` was renamed to `rotating-cert` to avoid sharing the name with the reference manual page.

A page redirect was added, and the index page updated.

Checked output in browser, no issues identified.

This commit addresses FFTK-2939

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
