### PR TITLE
Fix build setup requirement

### DIFF
--- a/source/user-guide/lmp-customization/linux-building.rst
+++ b/source/user-guide/lmp-customization/linux-building.rst
@@ -36,7 +36,7 @@ On Debian-based Linux distributions, including Ubuntu, run::
        texinfo g++ gcc-multilib build-essential chrpath socat cpio \
        openjdk-11-jre python2.7 python3 python3-pip python3-pexpect xz-utils \
        debianutils iputils-ping libsdl1.2-dev xterm libssl-dev libelf-dev \
-       android-tools-fsutils ca-certificates repo whiptail
+       android-sdk-libsparse-utils ca-certificates repo whiptail
 
 .. note::
 


### PR DESCRIPTION
Updated linux-building page, so that android-tools-fsutils is now android-sdk-libsparse-utils.

Small change, no QA done.

No issue opened.

## Readiness

*   [x] Merge (pending reviews)
*   [ ] Merge after _date or event_
*   [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._  
_You can fill this out after opening the PR. "Did I..."_

*   [x] Run spelling and grammar check, preferably with linter.
*   [x] Avoid changing any header associated with a link/reference.
*   [x] Step through instructions (or ask someone to do so).
*   [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
*   [x] Match tone and style of page/section.
*   [ ] Run `make linkcheck`.
*   [ ] View HTML in a browser to check rendering.
*   [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
*   [x] follow best practices for commits.
    *   [x] Descriptive title written in the imperative.
    *   [x] Include brief overview of QA steps taken.
    *   [x] Mention any related issues numbers.
    *   [x] End message with sign off/DCO line (`-s, --signoff`).
    *   [x] Sign commit with your gpg key (`-S, --gpg-sign`).
    *   [x] Squash commits if needed.
*   [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._  
_This could include potential issues, rational for approach, etc._