### PR TITLE
Correct the last example of a waves rollout

### DIFF
--- a/source/reference-manual/ota/production-targets.rst
+++ b/source/reference-manual/ota/production-targets.rst
@@ -263,6 +263,6 @@ A user can also dump a pre-selected device list into a file; then inspect, amend
 
     fioctl waves rollout v2.0-update --limit 1000 --print-uuids >/path/to/pre-selected.lst
     # Open and edit /path/to/pre-selected.lst using your editor of choice.
-    fioctl waves rollout v2.0-update --uuids >/path/to/pre-selected.lst
+    fioctl waves rollout v2.0-update --uuids @/path/to/pre-selected.lst
 
 One way or another, the Fioctl® allows you to implement various processes to roll out updates to your Factory device fleet.


### PR DESCRIPTION
The last example on the production-targets page had an incorrect format.

## Readiness

* [x ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
