### PR TITLE
Clarify warning for setting factory root of trust

### DIFF
--- a/source/reference-manual/security/device-gateway.rst
+++ b/source/reference-manual/security/device-gateway.rst
@@ -67,6 +67,9 @@ Setting up your PKI
 
 :ref:`ref-fioctl` includes a sub-command to set this up:
 
+.. warning::
+   The following command can only be used once.
+
 .. code-block::
 
     fioctl keys ca create /absolute/path/to/certs/
@@ -78,6 +81,10 @@ A few important things to note about this command:
 
  * The "PKI Directory" is important and should be securely backed
    up.
+
+ * As noted in the warning, it can only be set once.
+   A reset requires contacting `Customer Support <https://foundriesio.atlassian.net/servicedesk/customer/portals>`,
+   and will result in connected devices loosing connection.
 
 After running the above command, you can validate the outcome and view the configured certificates by using the following command:
 

--- a/source/user-guide/device-gateway-pki/device-gateway-pki.rst
+++ b/source/user-guide/device-gateway-pki/device-gateway-pki.rst
@@ -3,6 +3,15 @@
 Details Of Device Gateway PKI Settings
 ======================================
 
+.. warning::
+   The factory root of trust **can only be set once** —
+   `contact customer support<https://foundriesio.atlassian.net/servicedesk/customer/portals>` if you need to have the value reset.
+   This means the command ``fioctl keys ca create`` works only for the first run.
+   Subsequent attempts will fail.
+   Additionally,if you do have a reset performed, it will result in connected devices losing connection.
+   However, the Device CA bundle (``ca-crt``) can be updated many times;
+   you may add or remove local/offline CA certs for the bundle with ``fioctl keys ca update``.
+
 This guide covers Public Key Infrastructure (PKI) Settings.
 In particular, the low-level details of what happens behind the scenes when running the ``fioctl keys ca`` commands.
 It also provides instructions to create, sign, and use an *offline* (aka *local*) device certificate.
@@ -71,12 +80,6 @@ The following files are uploaded:
 1. ``tls-crt`` - the result of ``tls-csr`` signing;
 2. ``online-crt`` and ``local-ca.pem`` bundled together into the ``ca-crt`` field of the PATCH request;
 3. ``factory_ca.pem`` - root CA certificate created by running ``create_ca`` transferred via ``root-crt`` fields of the PATCH request.
-
-.. warning::
-   The factory root of trust can be set once—contact customer support if you need to have the value reset.
-   Thus, the given command ``fioctl keys ca create`` works only for the first run, subsequent command calls will fail.
-   However Device CA bundle (``ca-crt``) can be updated many times;
-   a user may add or remove local/offline CA certs to and from the bundle with ``fioctl keys ca update``.
 
 Device Key and Certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/user-guide/rotating-cert.rst
+++ b/source/user-guide/rotating-cert.rst
@@ -23,6 +23,8 @@ The resulting TLS certificate will be used by the FoundriesFactory EST server.
 .. note::
    This option requires the FoundriesFactory® backend to have a certificate authority to sign renewal requests.
    This "online-ca" is configured when running ``fioctl keys ca create``.
+   Please note that ``fioctl keys ca create`` can **only** be run once;
+   see :ref:`ref-device-gateway-pki-details` for more information.
 
 User Managed
 ~~~~~~~~~~~~


### PR DESCRIPTION
Moved warning for `fioctl keys ca create` to device-gateway-pki page. Added info to the other two applicable pages.

QA Steps: Checked rendered output.

No issues to link.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

This commit attempts to address issues discussed in slack.
The idea is to make it more clear that `fioctl keys ca create` is largely a one time only/single-use command.

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
