### PR TITLE
Cleanup wireguard reference manual

### DIFF
--- a/source/reference-manual/remote-access/remote-access.rst
+++ b/source/reference-manual/remote-access/remote-access.rst
@@ -3,6 +3,8 @@
 Remote Access
 =============
 
+This section covers setting up, using, and troubleshooting WireGuard® VPN for your devices.
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
The remote access section of the reference manual (wireguard) was cleaned up to adhere to the style-guide. Added additional content for troubleshooting, and worked on clarifying potential points of confusion.

QA steps: Ran link-check and linter. Checked build output, no issues found with rendering.

This commit addresses FFTK-1704
This commit addresses FFTK-2794
This commit addresses FFTK-2954

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview


## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Feel free to suggest additional info or changes!