### PR TITLE
ug: lmp-customization: add instruction to escape passwd with printf

### DIFF
--- a/source/user-guide/lmp-customization/lmp-customization.rst
+++ b/source/user-guide/lmp-customization/lmp-customization.rst
@@ -318,7 +318,14 @@ Adding LmP Users
 
        \$6\$OJHEGl4Dk5nEwG6k\$z19R1jc7cCfcQigX78cUH1Qzf2HINfB6dn6WgKmMLWgg967AV3s3tuuJE7uhLmBK.bHDpl8H5Ab/B3kNvGE1E.
 
-   This is the ``USER_PASSWD``/``LMP_PASSWORD`` to be added to the build as the new user password.   
+#. You can also escape any special characters by using the ``printf`` command in bash:
+
+   .. code-block:: none
+
+       password_hash=`mkpasswd -m sha512crypt`
+       printf '%q' "$password_hash"
+
+   This is the ``USER_PASSWD``/``LMP_PASSWORD`` to be added to the build as the new user password.
 
 #. If including a new user, add the following block to ``meta-subscriber-overrides/recipes-samples/images/lmp-factory-image.bb``:
 


### PR DESCRIPTION
bash printf has an easy way to escape any special character.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Facilitate the life of the user creating a custom password.

## Checklist

_Optional. Add a 'x' to steps taken._
_You can fill this out after opening the PR. "Did I..."_

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.