### PR TITLE
user-guide: additional config for lmp-device-auto-register

### DIFF
--- a/source/user-guide/lmp-device-auto-register/lmp-device-auto-register.rst
+++ b/source/user-guide/lmp-device-auto-register/lmp-device-auto-register.rst
@@ -108,6 +108,41 @@ When the CI finishes, download and flash the image.
   To get a better understanding of what is going on, one can look at the lmp-device-auto-register_ repo.
   The Systemd Service file and corresponding shell script can be customized, just like the API token file is being overwritten.
 
+Additional Configuration
+------------------------
+
+Auto registration can use device tags and HSM.
+Additional configuration can be added by creating files in ``/etc/sota`` directory
+
+Registering the device with a tag can be done by creating ``/etc/sota/tag`` file.
+The file should contain only the tag.
+Example ``tag`` file:
+
+::
+
+    postmerge
+
+Registering the device using HSM can be done by creating ``/etc/sota/hsm`` file.
+The file should contain the following contents:
+
+::
+
+    HSM_MODULE=</path/to/module>
+    HSM_PI=<PIN value>
+    HSM_SOPIN=<SO pin value>
+
+Example ``hsm`` file for SE050 device
+
+::
+
+    HSM_MODULE="/usr/lib/libckteec.so.0"
+    HSM_PI=87654321
+    HSM_SOPIN=12345678
+
+``lmp-device-auto-register`` recipe does not create these files.
+They need to be created by the user either by amending the ``lmp-device-auto-register`` recipe,
+or by creating a separate recipe.
+
 Testing Auto Register
 ---------------------
 


### PR DESCRIPTION
lmp-device-auto-register script can register device with additional tags and using HSM. This patch describes how to use these options.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

lmp-device-auto-register script can register device with additional tags and using HSM. This patch describes how to use these options.

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.


