### PR TITLE
Document that a user may have one active wave per tag at a time

### DIFF
--- a/source/reference-manual/ota/production-targets.rst
+++ b/source/reference-manual/ota/production-targets.rst
@@ -61,6 +61,12 @@ There are several ways how a wave can be rolled out:
 - To a subset of devices in a Factory (potentially, across several device groups, including group-less devices).
 - To all devices in a Factory.
 
+.. note::
+
+    You may create as many waves as you need for your release strategy.
+    But, there may be only one active wave per device tag at a time.
+    If you need to roll out more than one wave to one tag, either complete or cancel a previous wave to that tag.
+
 We recommend that you first roll out a wave to a dedicated device group, which contains a small number of production devices.
 Another good option is to roll out a wave to a small subset of devices in a bigger device group.
 Let us assume you want to first roll out a new ``v2.0-update`` wave to a device group called ``canary``.


### PR DESCRIPTION
# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

In the past we had a limitation of only one active wave at a time.
However, we did not document this limitation anywhere, as we wanted to see what our customers expect from this feature.

Our customers were requesting an ability to run more than one wave at a time.
So, in Q3 2023 we loosened this limitation to allow one active wave per tag at a time.
This is a fair trade-off between user convenience and safety, so that needs to be documented.