### PR TITLE
Fix linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -135,7 +135,11 @@ linkcheck_ignore = [
     'https://mgmt.foundries.io/leshan/#/security',
     'https://github.com/foundriesio/fiotest#testing-specification',
     'https://github.com/foundriesio/jobserv/blob/72935348e902cdf318cfee6ab00acccee1438a7c/jobserv/notify.py#L141-L146',
+    'https://www.st.com/en/development-tools/stm32cubeprog.html', #slow, very slow.
 ]
+
+# Time in seconds to wait for a response. May result infalse errors, but also keeps things from timing out
+linkcheck_timeout = 5
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Added a 5 second timeout for links, and skipping one which often takes a good long while seems to have linkcheck completing again, at least locally.

QA: ran linkcheck

Jira issue: none

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Hopefully this will work for our CI as well. If not, there are a few other things we can try.

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
