### PR TITLE
rm: factory: Add info on TUF targets expiration configuration

### DIFF
--- a/source/reference-manual/factory/factory-definition.rst
+++ b/source/reference-manual/factory/factory-definition.rst
@@ -46,6 +46,27 @@ notify:
 
         **Default:** ``false``
 
+.. _def-tuf-expiration:
+
+``tuf``
+-------
+Configures the validity period of the Factory TUF targets role metadata
+
+.. sidebar:: ``tuf:`` Section Example
+
+    .. code-block:: yaml
+
+         tuf:
+           targets_expire_after: "2Y33M44D"
+
+tuf:
+  targets_expire_after: ``<validity-period>``
+    **Optional:** Validity period of the CI TUF targets metadata since Target creation by a CI build.
+    It can be expressed in years, months, and days, with each component being optional.
+    The format must follow the order of years, months, and days, as demonstrated by ``1Y3M5D``.
+
+    **Default:** ``1Y``
+
 .. _def-lmp:
 
 lmp
@@ -189,8 +210,6 @@ Variables
                Defaults to the directory mounted on the SDK build container.
                If this directory exists, it is used as the source for the shared state cache (``sstate-cache``) mirror.
                When the directory does not exist, the ``lmp-manifest`` value is used (currently points to the public HTTP shared state cache).
-* **TUF_TARGETS_EXPIRE**:
-               Is used to change the default target expiration date (default 1y).
 
 .. _def-containers:
 


### PR DESCRIPTION
It turned the current info on the TUF targets expiration configuration is not quite accurate. It suggests to use `<build-type>.params.TUF_TARGETS_EXPIRE` parameters which is rather an internal mechanism and should not be recommended for users.

The proper way to set targets metadata default validity period is through the `tuf.targets_expire_after` parameter, this is the one that we should recommend to users.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [ ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [ ] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [ ] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [ ] follow best practices for commits.
  * [ ] Descriptive title written in the imperative.
  * [ ] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [ ] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [ ] Squash commits if needed.
* [ ] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
