### PR TITLE
Fix broken link to ti documentation

### DIFF
--- a/source/reference-manual/boards/am64xx-sk-prepare.rst
+++ b/source/reference-manual/boards/am64xx-sk-prepare.rst
@@ -13,7 +13,7 @@ When building the Cortex R5 U-Boot, all variants are built:
   All secrets within the device are fully protected and all of the security goals are fully enforced.
   The device also enforces secure booting.
 
-* ``gp`` (General Purpose), also known as `SK-AM64`_: This is a SoC/board state with no device protection and authentication is not enabled for booting the device.
+* ``gp`` (General Purpose), also known as SK-AM64: This is a SoC/board state with no device protection and authentication is not enabled for booting the device.
 
 The default variant is  ``hs-fs``.
 To boot an image on other variants without pre-flash files manipulations on the target file-system, we need to change the ``SYSFW_SUFFIX`` variable.
@@ -32,5 +32,3 @@ The following changes the default to ``gp``, so that the image produced boots th
 .. _SK-AM64B:
    https://www.ti.com/tool/SK-AM64B
 
-.. _SK-AM64:
-   https://www.ti.com/tool/SK-AM64


### PR DESCRIPTION
Removed link which was resulting in a 404. No suitable alternative found, and does not seem necessary.

QA Steps: Read page to make sure link could be removed without major loss of information. Ran Linkcheck and built documentation. No issues spotted.

No issues to link, minor fix.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
