### PR TITLE
requirements: Include requirement for setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==69.2.0
 sphinx-rtd-theme==1.3.0
 sphinx==5.3.0
 sphinxcontrib-contentui==0.2.5


### PR DESCRIPTION
This wasn't required on x86/linux but I discovered it was required for arm/macos

