### PR TITLE
Add lost container preloading info

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -422,6 +422,7 @@ redirects = {
      "reference-manual/linux/linux-building": "../../user-guide/lmp-customization/linux-building.html",
      "reference-manual/linux/linux-extending": "../../user-guide/lmp-customization/linux-extending.html",
      "reference-manual/qemu/qemu": "../../user-guide/qemu/qemu.html",
+     "reference-manual/linux/preloaded-images": "../../user-guide/containers-and-docker/container-preloading.html"
       }
 
 # Make external links open in a new tab.


### PR DESCRIPTION
Information that was on the removed
`reference-manual/linux/preloaded-images` page that did not migrate to the user-guide page was added.

QA: visually inspected html, checked with linter. No issues spotted.

No associated Ticket/Issue, as this was a quick fix.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Focus was mostly upon copying the old information and cleaning it up. Open to suggestions if context or content needs additional work. Redirect was also added.

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
