### PR TITLE
Remove deprecated sstate-cache-mirror reference

### DIFF
--- a/source/reference-manual/factory/factory-definition.rst
+++ b/source/reference-manual/factory/factory-definition.rst
@@ -206,10 +206,6 @@ Variables
 * **DISTRO**:
                Defines the distro being used.
                Reference: :ref:`ref-linux-distro`.
-* **SSTATE_CACHE_MIRROR**:
-               Defaults to the directory mounted on the SDK build container.
-               If this directory exists, it is used as the source for the shared state cache (``sstate-cache``) mirror.
-               When the directory does not exist, the ``lmp-manifest`` value is used (currently points to the public HTTP shared state cache).
 
 .. _def-containers:
 


### PR DESCRIPTION
This commit removes 1 of 2 reference, with the other being included in PR #712.

QA Steps: Checked rendered output, no issues seen.

No related ticket, small fix.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
