### PR TITLE
Fix broken refs in board flashing instructions

### DIFF
--- a/source/reference-manual/boards/imx6ull.rst
+++ b/source/reference-manual/boards/imx6ull.rst
@@ -64,7 +64,7 @@ i.MX 6ULL Evaluation Kit
 
 .. |secure_boot_pre_flash_note| replace:: For instructions on how to sign the
      required images before flashing them to the board with secure boot enabled,
-     see:ref:`ref-secure-machines`.
+     see :ref:`ref-secure-machines`.
 
 Pre-Preparation
 ---------------

--- a/source/reference-manual/boards/imx8mp.rst
+++ b/source/reference-manual/boards/imx8mp.rst
@@ -65,7 +65,7 @@ i.MX 8M Plus Evaluation Kit
     :ref:`ref-security`  details the required background for secure boot.
 
 .. |secure_boot_pre_flash_note| replace:: For instructions on how to sign the
-     required images before flashing them to the board with secure boot enabled,
-     see:ref:`ref-secure-machines`
+    required images before flashing them to the board with secure boot enabled,
+    see :ref:`ref-secure-machines`
 
 .. include:: imx-common-board.inc

--- a/source/reference-manual/boards/imx8mq.rst
+++ b/source/reference-manual/boards/imx8mq.rst
@@ -63,6 +63,6 @@ i.MX 8M Quad Evaluation Kit
 
 .. |secure_boot_pre_flash_note| replace:: For instructions on how to sign the
      required images before flashing them to the board with secure boot enabled,
-     see:ref:`ref-secure-machines`
+     see :ref:`ref-secure-machines`
 
 .. include:: imx-common-board.inc

--- a/source/reference-manual/boards/secure-boot-pre-flash-note.rst
+++ b/source/reference-manual/boards/secure-boot-pre-flash-note.rst
@@ -1,4 +1,3 @@
 .. note::
-
-     For instructions on how to sign the required images before flashing them to the board with secure boot enabled,
-     follow the instructions from :ref:`ref-secure-machines`.
+   For instructions on how to sign the required images before flashing them to the board with secure boot enabled,
+   follow the instructions from :ref:`ref-secure-machines`.


### PR DESCRIPTION
Missing whitespace was causing internal doc links to not be rendered into html for some of the imx flashing instructions.

QA Steps: checked rendered output, no issues spotted.

No related ticket, minor fix

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
