### PR TITLE
Add meilisearch for docs search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ sphinx_copybutton==0.5.2
 sphinx_toolbox==3.5.0
 sphinx-prompt==1.5.0
 sphinx-reredirects
+sphinx-autobuild
+meilisearch

--- a/source/_templates/searchbox.html
+++ b/source/_templates/searchbox.html
@@ -1,0 +1,33 @@
+{% if search_version == 'default'  %}
+
+<div role="search">
+  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+    <input type="text" name="q" placeholder="{{ _('Using builtin search') }}" aria-label="{{ _('Search docs') }}" />
+    <input type="hidden" name="check_keywords" value="yes" />
+    <input type="hidden" name="area" value="default" />
+  </form>
+</div>
+
+{% else %}
+
+<div id="search"></div>
+
+<script src="https://unpkg.com/meilisearch-docsearch@latest/dist/index.global.js"></script>
+<script>
+    
+    const { docsearch } = window.__docsearch_meilisearch__;
+    docsearch({
+      container: "#search",
+      host: "{{ meilisearch_host }}",
+      apiKey: "{{ meilisearch_search_key }}",
+      indexUid: "{{ search_version }}",
+    });
+
+</script>
+
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/meilisearch-docsearch@latest/dist/index.css"
+/>
+
+{% endif %}


### PR DESCRIPTION
Added search functionality.

Two api keys are exposed, with limited scope.
The search api, which is normal and required for basic search functionality.
An additional key allows for getting the list of indexes. This allows for checking if an index matching the release exists.

If no index exists, the default doc search is used.

Known issues: as a limit to the number of indexes/releases will eventually present itself, older indexes will need to be deleted. As Sphinx is static, this presents a bit of an issue. However, once version selection is implemented, older versions will be rebuilt, meaning older releases with deleted search indexes will fallback to using the default Sphinx search.

Additionally, local/PR CI builds will use a "dev" index. This will eventually be configured to use the most recent commit, however for now the index was created by scrapping "latest".

Note this commit does NOT cover the creation of indexes, which at this time will be handled manually, and requires private keys.

QA: Checked rendered output, and tested a number of cases by modifying the variables used.

This commit addresses task FFTK-3215
This commit applies to task FFTK-3091

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

DOC SEARCH

## Checklist

* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Additional styling and configuration will be added in the future.
I also do not do Python, so code in `conf.py` is not optimized or pretty in anyway. 
