### PR TITLE
Add admonition for credential helper on macOS

### DIFF
--- a/source/user-guide/containers-and-docker/configure-docker-helper.rst
+++ b/source/user-guide/containers-and-docker/configure-docker-helper.rst
@@ -9,6 +9,20 @@ This enables the use of Docker commands from a personal computer, such as a lapt
 .. note::
    The :ref:`credentials<ref-api-access>` will need the “containers:read” scope to work with Docker.
 
+.. important::
+   On macOS, you may encounter authentication issues.
+   This is due to Git on OSX using the Keychain Access Utility.
+   Git attempts to use this for authentication before ``git-credential-fio``.
+
+   The solution is to remove Keychain Access entries from your git config file.
+   Locate the git config by running::
+
+    git config -l --show-origin | grep credential
+  
+   Edit the gitconfig file with ``credential.helper=osxkeychain``, commenting out the line.
+
+   Fioctl should now be able to authenticate.
+
 To do this, run:
 
 .. code:: bash


### PR DESCRIPTION
Used the `important` admonition with how to locate the line to comment out to get the credential helper to work on macOS. Left out other troubleshooting steps, which can be added if warranted.

QA steps: checked rendered output in browser, ran linter.

No related tasks, quick fix.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
