### PR TITLE
Apply new RTD theme options

### DIFF
--- a/source/_static/theme_overrides.css
+++ b/source/_static/theme_overrides.css
@@ -102,3 +102,6 @@ li {
 html.writer-html5 .rst-content dl.field-list>dt:after {
     content: initial;
 }
+.wy-nav-side {
+      background: #2C1256;
+    }

--- a/source/conf.py
+++ b/source/conf.py
@@ -299,7 +299,12 @@ html_theme = 'sphinx_rtd_theme'
 # than canonical_url
 html_theme_options = {
     'logo_only': True,
-    'canonical_url': 'https://docs.foundries.io/latest/'
+    'canonical_url': 'https://docs.foundries.io/latest/',
+    'collapse_navigation': False,
+    'sticky_navigation': False,
+    'navigation_depth': -1,
+    'style_external_links': True,
+    'style_nav_header_background': '#2C1256',
 }
 
 


### PR DESCRIPTION
Applied theme changes that are configurable without modifying CSS or HTML. Deeper changes to the theme can always be investigated later.

Changes of note:

* "+" symbol in sidebar next to sections which can be expanded to show subsections. We may wish to investigate changing the color to increase visibility, if this is an option we want to add to the docs.

* Background color of sidebar updated to match website

* External links are styled, so as to indicate such.

QA steps: viewed rendered html in browser, ran linkcheck.

No associated issue, minor changes to test out.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [ ] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [ ] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

This is just to test out some theme options, to see if we wish to adopt any of them.