### PR TITLE
Some fixup

### DIFF
--- a/source/reference-manual/security/boot-software-updates-imx8qm.rst
+++ b/source/reference-manual/security/boot-software-updates-imx8qm.rst
@@ -290,9 +290,9 @@ Example of board ``boot.cmd``
     setenv bootcmd_boot_hdmi 'hdp load ${loadaddr}'
     setenv bootcmd_boot_m4_0 'dcache flush; bootaux ${loadaddr} 0'
     setenv bootcmd_boot_m4_1 'dcache flush; bootaux ${loadaddr} 1'
-    setenv bootcmd_load_hdmi 'if imxtract ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR@@freescale_${fdt_file} loadable@@FIT_NODE_SEPARATOR@@${hdmi_image} ${loadaddr}; then run bootcmd_boot_hdmi; fi'
-    setenv bootcmd_load_m4_0 'if imxtract ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR@@freescale_${fdt_file} loadable@@FIT_NODE_SEPARATOR@@${m4_0_image} ${loadaddr}; then run bootcmd_boot_m4_0; fi;'
-    setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR@@freescale_${fdt_file} loadable@@FIT_NODE_SEPARATOR@@${m4_1_image} ${loadaddr}; then run bootcmd_boot_m4_1; fi;'
+    setenv bootcmd_load_hdmi 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${hdmi_image} ${loadaddr}; then run bootcmd_boot_hdmi; fi'
+    setenv bootcmd_load_m4_0 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${m4_0_image} ${loadaddr}; then run bootcmd_boot_m4_0; fi;'
+    setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${m4_1_image} ${loadaddr}; then run bootcmd_boot_m4_1; fi;'
     setenv bootcmd_load_fw 'run bootcmd_load_hdmi; run bootcmd_load_m4_0; run bootcmd_load_m4_1;'
 
     # Boot firmware updates

--- a/source/reference-manual/security/factory-keys.rst
+++ b/source/reference-manual/security/factory-keys.rst
@@ -124,12 +124,6 @@ When a Factory is created, by default, two sets of keys are created under
 * ``factory-keys``: The key set is created during the Factory's creation
   and is unique for that Factory.
 
-.. warning::
-
-        FoundriesFactories created prior to **v83** do not have the ``factory-keys``
-        directory with the set of keys and certificates. In this case, the commands
-        can be used to create the files.
-
 A pair comprises a certificate (``*.crt``) and a key (``*.key``) file.
 
 The name of the key indicates by which component the **public** part of the key is used.


### PR DESCRIPTION
Remove `FIT_NODE_SEPARATOR` which is deprecated in https://github.com/foundriesio/meta-lmp/pull/1504

Remove v83 warning message as it's too old