### PR TITLE
RM: security: Remove the dev certificate references

### DIFF
--- a/source/reference-manual/security/factory-keys.rst
+++ b/source/reference-manual/security/factory-keys.rst
@@ -134,8 +134,6 @@ A pair comprises a certificate (``*.crt``) and a key (``*.key``) file.
 
 The name of the key indicates by which component the **public** part of the key is used.
 
-The **dev** pair is a generic ``RSA`` 2048 key pair and is not in use.
-
 The **opteedev** pair is a ``RSA`` 2048 key pair by ``OP-TEE`` to validate trusted
 applications run by ``OP-TEE``. This is used by configuring the variable ``OPTEE_TA_SIGN_KEY``.
 
@@ -152,37 +150,44 @@ This is used by configuring the variable ``MODSIGN_PRIVKEY``.
 
 The **UEFI** certificates are detailed in :ref:`ref-secure-boot-uefi`.
 
+The **TF-A** certificates are detailed in :ref:`ref-factory-key-tfa`.
+
 The directory structure is shown below:
 
    .. parsed-literal::
-        lmp-manifest/
-        ├── conf
-        │   ├── keys
-        │   │   ├── dev.crt
-        │   │   ├── dev.key
-        │   │   ├── opteedev.crt
-        │   │   ├── opteedev.key
-        │   │   ├── privkey_modsign.pem
-        │   │   ├── spldev.crt
-        │   │   ├── spldev.key
-        │   │   ├── tf-a
-        │   │   ├── ubootdev.crt
-        │   │   ├── ubootdev.key
-        │   │   ├── uefi
-        │   │   ├── x509.genkey
-        │   │   └── x509_modsign.crt
-        │   └── local.conf
-        ├── factory-keys
-        │   ├── opteedev.crt
-        │   ├── opteedev.key
-        │   ├── privkey_modsign.pem
-        │   ├── spldev.crt
-        │   ├── spldev.key
-        │   ├── tf-a
-        │   ├── ubootdev.crt
-        │   ├── ubootdev.key
-        │   ├── uefi
-        │   └── x509_modsign.crt
+        lmp-manifest/factory-keys
+        ├── opteedev.crt
+        ├── opteedev.key
+        ├── privkey_modsign.pem
+        ├── spldev.crt
+        ├── spldev.key
+        ├── tf-a
+        │   └── privkey_ec_prime256v1.pem
+        ├── ubootdev.crt
+        ├── ubootdev.key
+        ├── uefi
+        │   ├── DB.auth
+        │   ├── DB.cer
+        │   ├── DB.crt
+        │   ├── DB.esl
+        │   ├── DB.key
+        │   ├── DBX.auth
+        │   ├── DBX.cer
+        │   ├── DBX.crt
+        │   ├── DBX.esl
+        │   ├── DBX.key
+        │   ├── KEK.auth
+        │   ├── KEK.cer
+        │   ├── KEK.crt
+        │   ├── KEK.esl
+        │   ├── KEK.key
+        │   ├── PK.auth
+        │   ├── PK.cer
+        │   ├── PK.crt
+        │   ├── PK.esl
+        │   ├── PK.key
+        │   └── PKnoauth.auth
+        └── x509_modsign.crt
 
 How to Rotate the FoundriesFactory Keys
 """""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
The conf/keys certificates is not used anymore (and not supposed to be used), so it is removed from every factory with this commit https://github.com/foundriesio/partner-setup/commit/74d7d3fe0c2a3fea189cf2e23ce0f18ee9cb6814

However, it is already present in the fresh new factories, as every factory copies from public lmp-manifest (which includes the conf/keys) and only when the first target is built that directory is removed.

It means, while the factory only has the First Fast Target, the conf/keys is there!

The conf/keys directory from lmp-manifest should not be removed (as they are needed when building LmP without a factory)

Please let me know if you prefer to see the content of directories tf-a and uefi.
