### PR TITLE
Add link to rgb3gen2 flashing instructions

### DIFF
--- a/source/reference-manual/boards/boards.rst
+++ b/source/reference-manual/boards/boards.rst
@@ -5,9 +5,11 @@ Supported Boards
 
 Select your board below to view flashing instructions.
 
+
 .. toctree::
    :maxdepth: 1
 
+   RB3G2 <https://github.com/foundriesio/meta-partner/blob/qualcomm/README.md#qualcomm-robotics-rb3g2-development-kit>
    beagleboneblack
    raspberrypi
    portenta-x8


### PR DESCRIPTION
Link added to supported boards page.

Built html, checked that link showed and functioned as intended, No issues found.

This commit addresses FFTK-3472 "RB3G2: link to flashing instructions"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Keeping it simple; shows up in TOC for board flashing instructions, links to our external flashing instructions. This will make it easy if the instructions are ever added directly to the docs.
