### PR TITLE
Add where to set uefi variables

### DIFF
--- a/source/reference-manual/security/secure-boot-uefi.rst
+++ b/source/reference-manual/security/secure-boot-uefi.rst
@@ -61,7 +61,7 @@ The most commonly found modes are:
 **Standard Mode**
 
   Signature and hash checks are enforced on boot time executables.
-  Microsoft KEK and DB certificates usually available.
+  Microsoft KEK and DB certificates are usually available.
   System vendors may include their own KEK and/or DB certificates.
 
 **User/Custom Mode**
@@ -123,7 +123,8 @@ Custom keys can be added to the ``lmp-manifest`` repo directory ``factory-keys/u
 Enabling UEFI Secure Boot Usage in LmP
 --------------------------------------
 
-The signing process in LmP is controlled by the following Yocto Project variables:
+The signing process in LmP is controlled by the following Yocto Project variables,
+set in ``meta-subscriber-overrides/conf/machine/include/lmp-factory-custom.inc``:
 
 * ``UEFI_SIGN_KEYDIR``
     * Path for the directory containing the DB private key (``DB.key`` and ``DB.crt``),
@@ -131,6 +132,12 @@ The signing process in LmP is controlled by the following Yocto Project variable
       and auth files (``PK.auth``, ``KEK.auth``, ``DB.auth``, and ``DBX.auth``)
 * ``UEFI_SIGN_ENABLE``
     * If set to ``1`` the systemd-boot bootloader and Linux kernel binaries will be signed by with the DB key (``DB.key`` at ``UEFI_SIGN_KEYDIR``)
+
+
+.. tip::
+
+   Setting these may not be required in cases where they are inherited from ``meta-lmp-bsp``.
+   This can be seen in ``meta-lmp/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc``
 
 .. _ref-secure-boot-uefi-provisioning:
 


### PR DESCRIPTION
Follow up to Slack discussion, the file the variables `UEFI_SIGN_ENABLE` `and UEFI_SIGN_KEYDIR` are set in was mentioned, as well as an admonition mentioning the case where this is not required.

QA steps: ran build and checked rendered HTML, ran linter. No issues found.

No related ticket, quick fix.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Let me know if I need to change anything, such as the file, or any unclear wording in the admonition.