### PR TITLE
Prepare docs for re-publishing of v94

### DIFF
--- a/source/user-guide/custom-sota-client.rst
+++ b/source/user-guide/custom-sota-client.rst
@@ -11,7 +11,7 @@ This is not always the desired operation. There are a couple ways to control thi
 
 #. Callbacks
 #. Custom Update Agent
-#. Command Line Interface - CLI (Aktualizr-lite Manual Mode)
+#. Command Line Interface - CLI (Aktualizr-lite Manual Mode) **Available in future release, v95**
 
 Callbacks
 ---------
@@ -56,7 +56,7 @@ Later, this can serve as an example to copy/paste into a Factory specific recipe
    https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-sota/custom-sota-client
 
 .. _SOTA client:
-   https://github.com/foundriesio/sotactl
+   https://github.com/foundriesio/aktualizr-lite/tree/v94/examples/custom-client-cxx
 
 Users can build this custom client into their LmP image with a small addition to ``meta-subscriber-overrides.git``:
 
@@ -72,11 +72,14 @@ Forking the Custom SOTA Client
 Producing a factory-specific SOTA client can be done by:
 
  #. Creating a Git repository for your custom code.
-    Cloning the `sotactl`_ repository and adding your repository as the remote is a good place to start.
+    Copying the `examples/custom-client-cxx`_ directory is a good place to start.
 
  #. Copying the `custom-sota-client`_ recipe from ``meta-lmp`` into ``meta-subscriber-overrides/recipes-sota``.
 
  #. Changing the ``custom-sota-client_git.bb`` Git references (``SRC_URI``, ``BRANCH``, ``SRCREV``) to point at your new sources.
+
+.. _examples/custom-client-cxx:
+   https://github.com/foundriesio/aktualizr-lite/tree/v94/examples/custom-client-cxx
 
 .. _sotactl:
    https://github.com/foundriesio/sotactl
@@ -91,7 +94,7 @@ In addition to the default daemon mode, users can run it as a CLI utility and pe
 
 .. prompt:: bash
 
-    sotactl --help
+    /build-custom/custom-sota-client --help
     Usage:
         sotactl [cmd] [options]
     Supported commands: check install run pull daemon
@@ -106,10 +109,14 @@ In addition to the default daemon mode, users can run it as a CLI utility and pe
 Command Line Interface - CLI (Aktualizr-lite Manual Mode)
 ---------------------------------------------------------
 
+.. attention::
+   The Aktualizr-lite CLI feature will be available for v95.
+   The content below is a preview.
+
 The ``aktualizr-lite`` executable can be invoked to perform individual operations allowing more control over the update flow.
 
 .. warning:: The Command Line Interface is in beta stage,
-    and is subject to change over the next releases.
+    and is subject to change over the following releases.
 
 .. note:: In order to use the run individual `aktualizr-lite` commands,
     the ``aktualizr-lite`` service needs to be stopped with ``sudo systemctl stop aktualizr-lite``


### PR DESCRIPTION
Admonition added for changes from commits 4e459db and e776a48, to allow for a re-release of docs v94. Post-publishing, this commit should be reverted/changes removed.

Built HTML and viewed in browser, ran linkcheck.

This commit addresses the issue in ticket FFTK-3545, Add temp admonitions for re-release

This commit applies to ticket FFTK-3544, Re-release v94 docs…

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

For re-release of v94

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
