### PR TITLE
Revert changes introduced for republishing v94

### DIFF
--- a/source/user-guide/custom-sota-client.rst
+++ b/source/user-guide/custom-sota-client.rst
@@ -11,7 +11,7 @@ This is not always the desired operation. There are a couple ways to control thi
 
 #. Callbacks
 #. Custom Update Agent
-#. Command Line Interface - CLI (Aktualizr-lite Manual Mode) **Available in future release, v95**
+#. Command Line Interface - CLI (Aktualizr-lite Manual Mode)
 
 Callbacks
 ---------
@@ -56,7 +56,7 @@ Later, this can serve as an example to copy/paste into a Factory specific recipe
    https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-sota/custom-sota-client
 
 .. _SOTA client:
-   https://github.com/foundriesio/aktualizr-lite/tree/v94/examples/custom-client-cxx
+   https://github.com/foundriesio/sotactl
 
 Users can build this custom client into their LmP image with a small addition to ``meta-subscriber-overrides.git``:
 
@@ -72,14 +72,11 @@ Forking the Custom SOTA Client
 Producing a factory-specific SOTA client can be done by:
 
  #. Creating a Git repository for your custom code.
-    Copying the `examples/custom-client-cxx`_ directory is a good place to start.
+    Cloning the `sotactl`_ repository and adding your repository as the remote is a good place to start.
 
  #. Copying the `custom-sota-client`_ recipe from ``meta-lmp`` into ``meta-subscriber-overrides/recipes-sota``.
 
  #. Changing the ``custom-sota-client_git.bb`` Git references (``SRC_URI``, ``BRANCH``, ``SRCREV``) to point at your new sources.
-
-.. _examples/custom-client-cxx:
-   https://github.com/foundriesio/aktualizr-lite/tree/v94/examples/custom-client-cxx
 
 .. _sotactl:
    https://github.com/foundriesio/sotactl
@@ -89,12 +86,13 @@ Producing a factory-specific SOTA client can be done by:
 
 Custom SOTA Client Work Modes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 By default, the example `SOTA client`_ works as a daemon updating a device to the latest version once it becomes available.
 In addition to the default daemon mode, users can run it as a CLI utility and perform specific steps of the update process separately.
 
 .. prompt:: bash
 
-    /build-custom/custom-sota-client --help
+    sotactl --help
     Usage:
         sotactl [cmd] [options]
     Supported commands: check install run pull daemon
@@ -108,10 +106,6 @@ In addition to the default daemon mode, users can run it as a CLI utility and pe
 
 Command Line Interface - CLI (Aktualizr-lite Manual Mode)
 ---------------------------------------------------------
-
-.. attention::
-   The Aktualizr-lite CLI feature will be available for v95.
-   The content below is a preview.
 
 The ``aktualizr-lite`` executable can be invoked to perform individual operations allowing more control over the update flow.
 


### PR DESCRIPTION
Changes made to enable the republishing of v94 have been reverted back; this path was considered easier than dealing with more complex git usage.

Built HTML, ran linkcheck and linter.

This commit addresses FFTK-3544, "Re-release v94 docs…"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments
