### PR TITLE
Add note that IPv6 is not supported

### DIFF
--- a/source/reference-manual/security/device-network-access.rst
+++ b/source/reference-manual/security/device-network-access.rst
@@ -3,6 +3,9 @@
 Device Network Access
 =====================
 
+.. important::
+   IPv6 is not supported for cloud services/device-gateway
+
 LmP devices have no ingress network requirements.
 However, they do need to connect to external services for device management:
 


### PR DESCRIPTION
Note added about ipv6 not supported for cloud services/device-gateway.

QA: linter, linkcheck, and viewed rendered HTML. No issues noted.

This commit addresses FFTK-2459, "Add note that IPv6 is not supported"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Working through older issues with quick fixes.
