### PR TITLE
Remove line causing docker build issues

### DIFF
--- a/source/reference-manual/docker/container-secrets.rst
+++ b/source/reference-manual/docker/container-secrets.rst
@@ -68,10 +68,6 @@ Update ``factory-config.yml`` from ci-scripts.git to instruct the build scripts 
 
 Update the Dockerfile for the container with something like::
 
- # syntax=docker/dockerfile:1.0.0-experimental
- # NOTE: - the first line must be this "syntax=" to enable this feature.
- FROM alpine
-
  # Docker places secrets under /run/secrets/<id>
  RUN --mount=type=secret,id=secret_1 echo "secret_1 is here:" && cat /run/secrets/secret_1
  RUN --mount=type=secret,id=secret_2 echo "secret_2 is here:" && cat /run/secrets/secret_2


### PR DESCRIPTION
Removed line reported to be causing issues due to no longer being required for secrets.

QA: Ran linter, linkcheck, and viewed rendered HTML.

This commit relates to FS-2820: "…Docker Build Stages Not Caching…"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

_Any thing else that a maintainer/reviewer should know._
_This could include potential issues, rational for approach, etc._
