### PR TITLE
Fix broken ref to board machine names page

### DIFF
--- a/source/user-guide/lmp-customization/linux-building.rst
+++ b/source/user-guide/lmp-customization/linux-building.rst
@@ -81,7 +81,7 @@ Setup Work Environment
 Next, set up your work environment for building the source.
 
 The supported ``MACHINE`` target used by this guide is ``qemuarm64-secureboot``.
-For information on other hardware platforms, see:ref:`ref-linux-supported`.
+For information on other hardware platforms, see :ref:`ref-linux-supported`.
 
 The default distribution variable, ``DISTRO``, is automatically set to ``lmp``.
 This distro is provided by the `meta-lmp-base` layer (see :ref:`ref-linux-layers` for more details).


### PR DESCRIPTION
Added space, link is now in the generated HTML as intended.

QA: checked rendered output and link. Ran linkcheck. No reason to run linter.

This commit addresses FS-2843, re: fix see:ref:ref-linux-supported

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)

## Overview

_Why merge this PR? What does it solve?_

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.
