### PR TITLE
Add note regarding CI and meta-subscriber-override

### DIFF
--- a/source/tutorials/customizing-the-platform/commit-and-push-recipe.rst
+++ b/source/tutorials/customizing-the-platform/commit-and-push-recipe.rst
@@ -60,6 +60,10 @@ Push:
 
    ``git push`` output will indicate the start of a new CI job.
 
+.. tip::
+   The CI builds from the most recent commit to ``meta-subscriber-overrides`` related branch at the time of the trigger.
+   A pinned manifest is produced to show you the exact code that produced the build.
+
 Go to https://app.foundries.io, select your Factory and click on :guilabel:`Targets`:
 
 The latest **Target** named :guilabel:`platform-main` should be the CI job you just created.


### PR DESCRIPTION
Note added to the tutorial.

QA: Ran linter, and checked rendered output in browser.

This commit addresses task FFTK-1895,"…CI and `meta-subscriber-overrides` commit usage"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)

## Overview

Older task from backlog to add documentation regarding CI and `meta-subscriber-overrides ` commit usage.

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Linkcheck only produced expected errors. 
