### PR TITLE
Fix a couple of trivial typos

### DIFF
--- a/source/reference-manual/ota/aktualizr-lite.rst
+++ b/source/reference-manual/ota/aktualizr-lite.rst
@@ -60,7 +60,7 @@ Parameters
 ~~~~~~~~~~
 
 The following are aktualizr-repo's configuration parameters that can be useful to modify.
-The presented values are the default one.
+The presented values are the default ones.
 
 .. code-block::
 

--- a/source/reference-manual/ota/fioconfig.rst
+++ b/source/reference-manual/ota/fioconfig.rst
@@ -16,7 +16,7 @@ The contents of each config file gets encrypted with the device's public key, us
 This means only someone owning the device's private key, and the device itself, can decrypt the value;
 Foundries.io, without the symmetric key, can not.
 
-Your Factory tracksthe last 10 config changes made to both the fleet, and each device.
+Your Factory tracks the last 10 config changes made to both the fleet, and each device.
 Your Factory keeps track of the last 10 config changes made to each device or device group config.
 
 .. important::


### PR DESCRIPTION
Tested by building the HTML docs.

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Fixes a couple of trivial typos

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [ ] Step through instructions (or ask someone to do so).
* [ ] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [ ] Match tone and style of page/section.
* [ ] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [ ] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [ ] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [ ] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

I tried to see why vale didn't catch these; I tried enabling other packages such as Google and Microsoft, but while that provided useful new suggestions, it still didn't catch the typos. When I set Vale.Spelling to YES in .vale.ini, it did catch the typos, but it also reported a ton of other errors even for words in accept.txt.