### PR TITLE
Document changes to fioctl git credential helper

### DIFF
--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -154,8 +154,8 @@ You can revoke this access and set up a new credential later once you are famili
 .. tip::
 
    We recommend creating a new API token for each computer you plan to use our tools with.
-   For example, if you intend to develop on both a laptop and a desktop, create a new token for each, as you would with SSH keys.
-   This way you can revoke tokens for individual systems, should they be compromised.
+   For example, if you develop on both a laptop and a desktop, create a new token for each, as you would with SSH keys.
+   This way you can revoke tokens for individual systems should they be compromised.
 
 Use the Client ID and Secret to finish the Fioctl login.
 
@@ -178,7 +178,7 @@ Use the Client ID and Secret to finish the Fioctl login.
      Client secret:
      You are now logged in to Foundries.io services.
 
-The following command can be used to test the ``fioctl`` configuration.
+Use the following command to test the configuration:
 
 .. prompt:: bash host:~$, auto
 
@@ -199,7 +199,9 @@ The following command can be used to test the ``fioctl`` configuration.
 Configuring Git
 ###############
 
-After :ref:`Fioctl <ref-fioctl>` is properly setup, it can be leveraged as a Git credential helper to allow pushing to your repositories with :ref:`FoundriesFactory® <ref-factory-definition>`. With this, Git knows when you connect to ``source.foundries.io`` and uses Fioctl for authentication when utilizing ``git`` commands.
+After :ref:`Fioctl <ref-fioctl>` is setup, you can leverage it as a Git credential helper.
+This allows pushing to your :ref:`Factory <ref-factory-definition>` repositories.
+With this, Git knows when you connect to ``source.foundries.io`` and uses Fioctl for authentication when utilizing ``git`` commands.
 
 Setting Up Git
 ^^^^^^^^^^^^^^
@@ -208,14 +210,11 @@ Run the following command to add the relevant entries to the Git configuration:
 
 .. prompt:: bash host:~$, auto
 
-   host:~$ sudo fioctl configure-git
-
-.. important::
-   This must run as ``sudo`` instead of directly as the ``root`` user.
-   This is because it needs to have privileges to create a symlink in the same directory as where ``git`` is located.
+   host:~$ fioctl configure-git
 
 .. warning::
-   * If for some reason the command ``sudo fioctl configure-git`` fails with an error, manual steps can be taken to get the exact same result. For comprehensive instructions, please see the :ref:`Fioctl™ Errors <ref-ts-errors>` section.
+   * If for some reason the command ``fioctl configure-git`` fails with an error, manual steps can be taken to get the exact same result.
+     For comprehensive instructions, please see the :ref:`Fioctl™ Errors <ref-ts-errors>` section.
 
    * Existing users reconfiguring Git access may need to remove the following lines from ``.gitconfig`` to use ``fioctl configure-git`` utility::
 

--- a/source/user-guide/troubleshooting/troubleshooting.rst
+++ b/source/user-guide/troubleshooting/troubleshooting.rst
@@ -10,11 +10,10 @@ This page covers a variety of topics falling under addressing specific :ref:`err
 Errors and Solutions
 ---------------------
 
-Fioctl™ Errors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Fioctl Errors
+^^^^^^^^^^^^^
 
-If for some reason the command ``sudo fioctl configure-git`` fails with an error, the following manual steps can be
-taken to get the exact same result:
+If ``fioctl configure-git`` fails with an error, manual steps can be taken to get the exact same result:
 
 1. Configure Git with the necessary credentials:
 
@@ -29,7 +28,7 @@ taken to get the exact same result:
 
  .. code-block:: bash
 
-    $ sudo fioctl configure-git
+    fioctl configure-git
     Symlinking /usr/local/bin/fioctl to /opt/homebrew/bin/git-credential-fio
     ERROR: symlink /usr/local/bin/fioctl /opt/homebrew/bin/git-credential-fio: file exists
 


### PR DESCRIPTION
Removed `sudo` for setting up Git with Fioctl.
May require further modifications.
Additionally, some changes made to further clean up the edited pages.

QA: Checked rendered output in browser.

This commit addresses issue FFTK-3728, "document changes to git cred..."

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)

## Overview

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.

## Comments

Linkcheck and linter errors reviewed and acknowledged, can be ignored. 
