### PR TITLE
Update linter style rules version

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@
 StylesPath = styles
 MinAlertLevel = suggestion
 
-Packages = https://github.com/foundriesio/fio-style/releases/download/v2.4.0/Fio-docs.zip
+Packages = https://github.com/foundriesio/fio-style/releases/download/v2.5.0/Fio-docs.zip
 
 # You can add different terms to either accept or reject by adding them to vocab.
 # This can be useful if you are using a new term or writing to a specific audience.


### PR DESCRIPTION
Updating to Fio-docs 2.5.0 which has a couple additions to check for.

QA: checked that vale sync worked and was able to fetch the package.

No associated issue, minor maintenance task.