### PR TITLE
Remove rpi3 from documentation

### DIFF
--- a/source/_static/csv/supported-boards.csv
+++ b/source/_static/csv/supported-boards.csv
@@ -16,7 +16,6 @@ Device Name,MACHINE
 :ref:`QEMU AARCH32 <ref-rm_qemu_arm>`,qemuarm
 :ref:`QEMU AARCH64 <ref-rm_qemu_arm64>`,qemuarm64-secureboot
 `Qualcomm RB3 Gen 2 <https://github.com/foundriesio/meta-partner/tree/qualcomm?tab=readme-ov-file#getting-started>`_,qcs6490-rb3gen2-vision-kit
-:ref:`Raspberry Pi3/3B (64 bit) <ref-rm_board_rasbperrypi>`,raspberrypi3-64
 :ref:`Raspberry Pi4 (and CM) <ref-rm_board_rasbperrypi>`,raspberrypi4-64
 :ref:`TI SK-AM62 <ref-rm_board_am62xx-sk>`,am62xx-evm
 :ref:`TI AM64x SKEVM <ref-rm_board_am64xx-sk>`,am64xx-evm

--- a/source/getting-started/flash-device/index.rst
+++ b/source/getting-started/flash-device/index.rst
@@ -168,12 +168,6 @@ If the above methods to SSH into your board do not work, there are additional th
 .. _zeroconf:
    https://en.wikipedia.org/wiki/Zero-configuration_networking
 
-.. _Adafruit USB to TTL Serial Cable:
-   https://www.adafruit.com/product/954
-
-.. _the Adafruit guide:
-   https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/connect-the-lead
-
 .. _Win32 Disk Imager: https://sourceforge.net/projects/win32diskimager/files/Archive/
 
 .. _7zip: https://www.7-zip.org/download.html

--- a/source/reference-manual/ota/device-tags.rst
+++ b/source/reference-manual/ota/device-tags.rst
@@ -14,11 +14,11 @@ Let us look at an example ``targets.json``::
   ...
   "signed": {
     "targets": {
-      "raspberrypi3-64-lmp-143" : {
+      "raspberrypi4-64-lmp-143" : {
         "custom" : {
           "createdAt" : "2019-08-12T22:18:16Z",
-          "hardwareIds" : ["raspberrypi3-64"],
-          "name" : "raspberrypi3-64-lmp",
+          "hardwareIds" : ["raspberrypi4-64"],
+          "name" : "raspberrypi4-64-lmp",
           "targetFormat" : "OSTREE",
           "updatedAt" : "2019-08-12T22:18:16Z",
           "version" : "143",
@@ -29,11 +29,11 @@ Let us look at an example ``targets.json``::
        },
        "length" : 0
       },
-      "raspberrypi3-64-lmp-144" : {
+      "raspberrypi4-64-lmp-144" : {
         "custom" : {
           "createdAt" : "2019-08-12T22:18:16Z",
-          "hardwareIds" : ["raspberrypi3-64"],
-          "name" : "raspberrypi3-64-lmp",
+          "hardwareIds" : ["raspberrypi4-64"],
+          "name" : "raspberrypi4-64-lmp",
           "targetFormat" : "OSTREE",
           "updatedAt" : "2019-08-12T22:18:16Z",
           "version" : "144",
@@ -70,7 +70,7 @@ Managing Tags
 By default, LmP builds are triggered for your Factory after code has been merged to main will be tagged with "postmerge".
 After doing QA on this build, it can be "promoted" using the Fioctl_ tool::
 
- fioctl targets tag -Tpostmerge,promoted raspberrypi3-64-lmp-144
+ fioctl targets tag -Tpostmerge,promoted raspberrypi4-64-lmp-144
 
 This will kick off a CI job that will tag build 144 as promoted.
 This would result in Device 2 (from the above example) in updating.

--- a/source/reference-manual/ota/targets.rst
+++ b/source/reference-manual/ota/targets.rst
@@ -10,7 +10,7 @@ A Target defines a cryptographically verifiable description of the software a de
 
 For a simplified example::
 
- "raspberrypi3-64-lmp-42" : {
+ "raspberrypi4-64-lmp-42" : {
     "hashes" : {"sha256" : "0xdeadbeef"},
     "custom" : {
       "version" : "42"
@@ -19,7 +19,7 @@ For a simplified example::
           "uri" : "hub.foundries.io/andy-corp/shellhttpd@sha256:0xdeadbeef"
         }
       },
-      "hardwareIds" : ["raspberrypi3-64"],
+      "hardwareIds" : ["raspberrypi4-64"],
       "tags" : ["master"],
     }
   }

--- a/source/reference-manual/testing/fiotest.rst
+++ b/source/reference-manual/testing/fiotest.rst
@@ -16,7 +16,7 @@ The API is built around a generic model for recording test results::
 
   Test:
     Name: string - "ltp"
-    Target: string - "raspberrypi3-64-lmp-8"
+    Target: string - "raspberrypi4-64-lmp-8"
     Device: string - device uuid
     Status: string - PASS/FAIL/RUNNING
     CreatedOn: timestamp - when the test was started
@@ -44,7 +44,7 @@ The API
     # Content-type: application/json
     {
       "name": "test-name",
-      "target": "raspberrypi3-64-lmp-8"
+      "target": "raspberrypi4-64-lmp-8"
     }
     # The CreatedOn value will be auto-populated by the server.
 

--- a/source/tutorials/configuring-and-sharing-volumes/copy-configuration-file-using-dockerfile.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/copy-configuration-file-using-dockerfile.rst
@@ -52,7 +52,7 @@ Commit and push the changes.
 Wait for the FoundriesFactory™ Platform's CI job to finish and for your device to receive the new target.
 
 To check if your device is up-to-date, from your Factory page check :guilabel:`Devices`.
-You should see a new number at the end of the **Target** name. For example, ``raspberrypi3-64-lmp-5``.
+You should see a new number at the end of the **Target** name. For example, ``raspberrypi4-64-lmp-5``.
 
 When the device is up-to-date, the **Status** icon will change to green.
 

--- a/source/tutorials/configuring-and-sharing-volumes/dynamic-configuration-file.rst
+++ b/source/tutorials/configuring-and-sharing-volumes/dynamic-configuration-file.rst
@@ -26,7 +26,7 @@ Use Fioctl on your host machine to remember your device name:
 
      NAME             FACTORY   TARGET                 STATUS   APPS        UP-TO-DATE
      ----             -------   ------                 ------   ----        ----------
-     <device-name>  <factory>  raspberrypi3-64-lmp-8  ONLINE   shellhttpd  true
+     <device-name>  <factory>  raspberrypi4-64-lmp-8  ONLINE   shellhttpd  true
 
 Now use Fioctl to set a configuration file:
 

--- a/source/tutorials/creating-first-target/what-is-a-target.rst
+++ b/source/tutorials/creating-first-target/what-is-a-target.rst
@@ -73,8 +73,8 @@ Before inspecting your latest **Target**, list all the **Targets**:
 
      VERSION  TAGS    APPS        HARDWARE IDs
      -------  ----    ----        ------------
-     1        main                raspberrypi3-64
-     2        main   shellhttpd  raspberrypi3-64
+     1        main                raspberrypi4-64
+     2        main   shellhttpd  raspberrypi4-64
 
 When you pushed your ``containers.git`` changes, it resulted in a new version, i.e.,  Target 3. 
 
@@ -100,15 +100,15 @@ Fioctl® can provide an overview of **Target**:
      
      TARGET NAME            OSTREE HASH - SHA256
      -----------            --------------------
-     raspberrypi3-64-lmp-4  3abd308ea6d4caffcdf250c7170e0dc9c8ff9082c64538bf14ca07c2df1beeff
+     raspberrypi4-64-lmp-4  3abd308ea6d4caffcdf250c7170e0dc9c8ff9082c64538bf14ca07c2df1beeff
      
      COMPOSE APP  VERSION
      -----------  -------
      shellhttpd   hub.foundries.io/<factory>/shellhttpd@sha256:3ce57a22faa2484ce602c86f522b72b1b105ce85a14fc5b2a9a12eb12de4ec7f
 
-The example above, shows a **Target Name** named ``raspberrypi3-64-lmp-4`` that:
+The example above, shows a **Target Name** named ``raspberrypi4-64-lmp-4`` that:
 
 - Is tagged with the ``main`` tag.
 - Specifies the OStree HASH corresponding to the latest ``platform-main`` build.
 - Lists all the container apps available, which in this case is just the ``shellhttpd`` app.
-- Based on the MACHINE ``raspberrypi3-64``.
+- Based on the MACHINE ``raspberrypi4-64``.

--- a/source/tutorials/deploying-first-app/debugging-your-device.rst
+++ b/source/tutorials/deploying-first-app/debugging-your-device.rst
@@ -27,14 +27,14 @@ You can also use ``fioctl`` to read information about your device.
      Owner:         6025791fd93b37d33e03b349
      Factory:	    <factory>
      Up to date:    true
-     Target:        raspberrypi3-64-lmp-4 / sha256(3abd308ea6d4caffcdf250c7170e0dc9c8ff9082c64538bf14ca07c2df1beeff)
+     Target:        raspberrypi4-64-lmp-4 / sha256(3abd308ea6d4caffcdf250c7170e0dc9c8ff9082c64538bf14ca07c2df1beeff)
      Ostree Hash:   3abd308ea6d4caffcdf250c7170e0dc9c8ff9082c64538bf14ca07c2df1beeff
      Created:       2021-04-20T20:54:37+00:00
      Last Seen:     2021-04-20T22:42:53+00:00
      Tags:          main
      Docker Apps:   shellhttpd
      Network Info:
-	     Hostname:  raspberrypi3-64
+	     Hostname:  raspberrypi4-64
 	     IP:        192.168.15.11
 	     MAC:       b8:27:eb:07:42:04
      Hardware Info:    (hidden, use --hwinfo)

--- a/source/tutorials/working-with-tags/adapting-shellhttpd.rst
+++ b/source/tutorials/working-with-tags/adapting-shellhttpd.rst
@@ -112,15 +112,15 @@ Check the Target version list with ``fioctl``
 
      VERSION  TAGS    APPS                                                   HARDWARE IDs
      -------  ----    ----                                                   ------------
-     2        devel                                                          raspberrypi3-64
-     3        main                                                         raspberrypi3-64
-     4        devel   shellhttpd                                             raspberrypi3-64
-     5        devel   shellhttpd                                             raspberrypi3-64
-     6        devel   shellhttpd                                             raspberrypi3-64
-     7        devel   shellhttpd                                             raspberrypi3-64
-     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi3-64
-     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     10       devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
+     2        devel                                                          raspberrypi4-64
+     3        main                                                           raspberrypi4-64
+     4        devel   shellhttpd                                             raspberrypi4-64
+     5        devel   shellhttpd                                             raspberrypi4-64
+     6        devel   shellhttpd                                             raspberrypi4-64
+     7        devel   shellhttpd                                             raspberrypi4-64
+     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi4-64
+     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     10       devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
 
 Check what Target your device is running:
 
@@ -132,7 +132,7 @@ Check what Target your device is running:
 
      NAME           FACTORY     TARGET                 STATUS  APPS                                        UP-TO-DATE
      ----           -------     ------                 ------  ----                                        ----------
-     <device-name>  <factory>   raspberrypi3-64-lmp-10 OK      flask-mqtt-nginx,mosquitto,shellhttpd-mqtt  true
+     <device-name>  <factory>   raspberrypi4-64-lmp-10 OK      flask-mqtt-nginx,mosquitto,shellhttpd-mqtt  true
 
 Whenever you push changes to the ``devel`` branch, the CI will build and generate a new Target tagged with ``devel``.
 As a result, devices following ``devel`` will update to the latest Target.

--- a/source/tutorials/working-with-tags/following-specific-tag.rst
+++ b/source/tutorials/working-with-tags/following-specific-tag.rst
@@ -18,15 +18,15 @@ Use ``fioctl`` on your host machine to list all Targets:
 
      VERSION  TAGS    APPS                                                   HARDWARE IDs
      -------  ----    ----                                                   ------------
-     2        devel                                                          raspberrypi3-64
-     3        main                                                           raspberrypi3-64
-     4        devel   shellhttpd                                             raspberrypi3-64
-     5        devel   shellhttpd                                             raspberrypi3-64
-     6        devel   shellhttpd                                             raspberrypi3-64
-     7        devel   shellhttpd                                             raspberrypi3-64
-     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi3-64
-     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     10       devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
+     2        devel                                                          raspberrypi4-64
+     3        main                                                           raspberrypi4-64
+     4        devel   shellhttpd                                             raspberrypi4-64
+     5        devel   shellhttpd                                             raspberrypi4-64
+     6        devel   shellhttpd                                             raspberrypi4-64
+     7        devel   shellhttpd                                             raspberrypi4-64
+     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi4-64
+     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     10       devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
 
 Use ``fioctl`` to Tag version 10:
 
@@ -37,7 +37,7 @@ Use ``fioctl`` to Tag version 10:
 ::
 
      [devel tutorial]
-     Changing tags of raspberrypi3-64-lmp-10 from [devel] -> [devel tutorial]
+     Changing tags of raspberrypi4-64-lmp-10 from [devel] -> [devel tutorial]
      CI URL: https://ci.foundries.io/projects/<factory>/lmp/builds/10
      # Waiting for worker with tag: amd64-partner.
      --- Status change: QUEUED -> RUNNING
@@ -118,15 +118,15 @@ Use ``fioctl`` again to list all Target versions:
 
      VERSION  TAGS    APPS                                                   HARDWARE IDs
      -------  ----    ----                                                   ------------
-     2        devel                                                                   raspberrypi3-64
-     3        main                                                                    raspberrypi3-64
-     4        devel            shellhttpd                                             raspberrypi3-64
-     5        devel            shellhttpd                                             raspberrypi3-64
-     6        devel            shellhttpd                                             raspberrypi3-64
-     7        devel            shellhttpd                                             raspberrypi3-64
-     8        devel            shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi3-64
-     9        devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     10       devel,tutorial   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
+     2        devel                                                                   raspberrypi4-64
+     3        main                                                                    raspberrypi4-64
+     4        devel            shellhttpd                                             raspberrypi4-64
+     5        devel            shellhttpd                                             raspberrypi4-64
+     6        devel            shellhttpd                                             raspberrypi4-64
+     7        devel            shellhttpd                                             raspberrypi4-64
+     8        devel            shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi4-64
+     9        devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     10       devel,tutorial   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
 
 Note that version 10 is now tagged with ``devel`` and ``tutorial``.
 

--- a/source/tutorials/working-with-tags/inspecting-targets.rst
+++ b/source/tutorials/working-with-tags/inspecting-targets.rst
@@ -15,15 +15,15 @@ Use ``fioctl`` on your host machine to list all Target versions:
 
      VERSION  TAGS    APPS                                                   HARDWARE IDs
      -------  ----    ----                                                   ------------
-     2        devel                                                          raspberrypi3-64
-     3        main                                                           raspberrypi3-64
-     3        main                                                           raspberrypi3-64
-     4        devel   shellhttpd                                             raspberrypi3-64
-     5        devel   shellhttpd                                             raspberrypi3-64
-     6        devel   shellhttpd                                             raspberrypi3-64
-     7        devel   shellhttpd                                             raspberrypi3-64
-     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi3-64
-     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
+     2        devel                                                          raspberrypi4-64
+     3        main                                                           raspberrypi4-64
+     3        main                                                           raspberrypi4-64
+     4        devel   shellhttpd                                             raspberrypi4-64
+     5        devel   shellhttpd                                             raspberrypi4-64
+     6        devel   shellhttpd                                             raspberrypi4-64
+     7        devel   shellhttpd                                             raspberrypi4-64
+     8        devel   shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi4-64
+     9        devel   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
 
 Note that though most versions are tagged with ``devel``, yours may be tagged as ``main``.
 This depends on if and when you created the ``devel`` branch.
@@ -44,9 +44,9 @@ Use ``fioctl`` on your host machine to verify what Target the device is running.
 
      NAME           FACTORY     TARGET                 STATUS  APPS                                        UP-TO-DATE
      ----           -------     ------                 ------  ----                                        ----------
-     <device-name>  <factory>   raspberrypi3-64-lmp-9  OK      flask-mqtt-nginx,mosquitto,shellhttpd-mqtt  true
+     <device-name>  <factory>   raspberrypi4-64-lmp-9  OK      flask-mqtt-nginx,mosquitto,shellhttpd-mqtt  true
 
-The device is running ``raspberrypi3-64-lmp-9``, which is the Target created for ``raspberrypi3-64`` in the build version ``9``.
+The device is running ``raspberrypi4-64-lmp-9``, which is the Target created for ``raspberrypi4-64`` in the build version ``9``.
 
 To check if your device is following the ``devel`` tag, use ``fioctl`` to inspect the device:
 
@@ -60,14 +60,14 @@ To check if your device is following the ``devel`` tag, use ``fioctl`` to inspec
      Owner:		5e13232f73927550af883e7b
      Factory:	<factory>
      Up to date:	true
-     Target:		raspberrypi3-64-lmp-9 / sha256(aa7bd4fd638dc1de1459d2d53bcd06887365483e270fb98b84cc8f9f61c44246)
+     Target:		raspberrypi4-64-lmp-9 / sha256(aa7bd4fd638dc1de1459d2d53bcd06887365483e270fb98b84cc8f9f61c44246)
      Ostree Hash:	aa7bd4fd638dc1de1459d2d53bcd06887365483e270fb98b84cc8f9f61c44246
      Created:	2021-05-25T14:36:44+00:00
      Last Seen:	2021-05-25T23:09:33+00:00
      Tags:		devel
      Docker Apps:	flask-mqtt-nginx,mosquitto,shellhttpd-mqtt
      Network Info:
-	     Hostname:	raspberrypi3-64
+	     Hostname:	raspberrypi4-64
 	     IP:		192.168.15.11
          MAC:		b8:27:eb:07:42:04
      Hardware Info: (hidden, use --hwinfo)

--- a/source/tutorials/working-with-tags/tagging-specific-version.rst
+++ b/source/tutorials/working-with-tags/tagging-specific-version.rst
@@ -11,18 +11,18 @@ Use Fioctl® on your host machine to list all Target versions:
 
      VERSION  TAGS    APPS                                                   HARDWARE IDs
      -------  ----    ----                                                   ------------
-     2        devel                                                                   raspberrypi3-64
-     3        main                                                                  raspberrypi3-64
-     4        devel            shellhttpd                                             raspberrypi3-64
-     5        devel            shellhttpd                                             raspberrypi3-64
-     6        devel            shellhttpd                                             raspberrypi3-64
-     7        devel            shellhttpd                                             raspberrypi3-64
-     8        devel            shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi3-64
-     9        devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     10       devel,tutorial   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     11       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     12       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
-     13       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi3-64
+     2        devel                                                                   raspberrypi4-64
+     3        main                                                                  raspberrypi4-64
+     4        devel            shellhttpd                                             raspberrypi4-64
+     5        devel            shellhttpd                                             raspberrypi4-64
+     6        devel            shellhttpd                                             raspberrypi4-64
+     7        devel            shellhttpd                                             raspberrypi4-64
+     8        devel            shellhttpd-mqtt,mosquitto,shellhttpd,flask-mqtt-nginx  raspberrypi4-64
+     9        devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     10       devel,tutorial   mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     11       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     12       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
+     13       devel            mosquitto,shellhttpd,flask-mqtt-nginx,shellhttpd-mqtt  raspberrypi4-64
 
 If you have any device following the ``devel`` tag, it should be running the latest Target.
 In the example above, this is version 13.
@@ -53,7 +53,7 @@ Use Fioctl to tag version you want, making sure to use the version you want from
 ::
 
      [devel tutorial]
-     Changing tags of raspberrypi3-64-lmp-12 from [devel] -> [devel tutorial]
+     Changing tags of raspberrypi4-64-lmp-12 from [devel] -> [devel tutorial]
      CI URL: https://ci.foundries.io/projects/<factory>/lmp/builds/12
      # Waiting for worker with tag: amd64-partner.
      --- Status change: QUEUED -> RUNNING

--- a/source/user-guide/containers-and-docker/compose-apps.rst
+++ b/source/user-guide/containers-and-docker/compose-apps.rst
@@ -76,7 +76,7 @@ The interesting part of the Target in this case is::
   ...
   "signed": {
     "targets": {
-      "raspberrypi3-64-lmp-144" : {
+      "raspberrypi4-64-lmp-144" : {
         "custom" : {
           "docker_compose_apps" : {
              "httpd" : {

--- a/source/user-guide/fioctl/index.rst
+++ b/source/user-guide/fioctl/index.rst
@@ -119,9 +119,9 @@ Target metadata can be inspected by using 3 primary commands:
            $ fioctl targets list
            VERSION  TAGS    APPS                             HARDWARE IDs
            -------  ----    ----                             ------------
-           1        main    simple-app,netdata               raspberrypi3-64
-           2        devel   mosquitto,simple-app,netdata     raspberrypi3-64
-           3        devel   simple-app,netdata,mosquitto     raspberrypi3-64
+           1        main    simple-app,netdata               raspberrypi4-64
+           2        devel   mosquitto,simple-app,netdata     raspberrypi4-64
+           3        devel   simple-app,netdata,mosquitto     raspberrypi4-64
 
 ``fioctl targets list -r``
     Lists the Targets a Factory has produced in ``-r`` (raw) json format.
@@ -150,27 +150,27 @@ Target metadata can be inspected by using 3 primary commands:
                 ],
                 "signed": {
                   "_type": "Targets",
-                  "expires": "2020-11-21T02:20:20Z",
+                  "expires": "2025-11-21T02:20:20Z",
                   "targets": {
-                    "raspberrypi3-64-lmp-57": {
+                    "raspberrypi4-64-lmp-58": {
                       "hashes": {
                         "sha256": "2d1655fb1e04e2ed39536dd96485687945ac87d6f9e7d79a01f06ec6e5d161b1"
                       },
                       "length": 0,
                       "custom": {
                         "cliUploaded": false,
-                        "name": "raspberrypi3-64-lmp",
-                        "version": "57",
+                        "name": "raspberrypi4-64-lmp",
+                        "version": "58",
                         "hardwareIds": [
-                          "raspberrypi3-64"
+                          "raspberrypi4-64"
                         ],
                         "targetFormat": "OSTREE",
-                        "uri": "https://ci.foundries.io/projects/cowboy/lmp/builds/53",
-                        "createdAt": "2020-10-21T02:20:18Z",
-                        "updatedAt": "2020-10-21T02:20:18Z",
+                        "uri": "https://ci.foundries.io/projects/cowboy/lmp/builds/58",
+                        "createdAt": "2025-10-21T02:20:18Z",
+                        "updatedAt": "2025-10-21T02:20:18Z",
                         "lmp-manifest-sha": "f39a2e1d1f81523ce222270ed9ddb3a87ff3ca09",
                         "arch": "aarch64",
-                        "image-file": "lmp-factory-image-raspberrypi3-64.wic.gz",
+                        "image-file": "lmp-factory-image-raspberrypi4-64.wic.gz",
                         "meta-subscriber-overrides-sha": "2cd6253273fc7de5ece8a45b9ec4247bcdd0556e",
                         "tags": [
                           "devel"
@@ -215,7 +215,7 @@ Target metadata can be inspected by using 3 primary commands:
 
            TARGET NAME             OSTREE HASH - SHA256
            -----------             --------------------
-           raspberrypi3-64-lmp-58  2d1655fb1e04e2ed39536dd96485687945ac87d6f9e7d79a01f06ec6e5d161b1
+           raspberrypi4-64-lmp-58  2d1655fb1e04e2ed39536dd96485687945ac87d6f9e7d79a01f06ec6e5d161b1
 
            COMPOSE APP   VERSION
            -----------   -------
@@ -237,14 +237,14 @@ View Targets
        $ fioctl targets list -f bebop
        VERSION  TAGS    APPS        HARDWARE IDs
        -------  ----    ----        ------------
-       2        devel               raspberrypi3-64
-       3        main                raspberrypi3-64
-       4        main    shellhttpd  raspberrypi3-64
-       5        main    shellhttpd  raspberrypi3-64
-       6        main                raspberrypi3-64
-       7        main                raspberrypi3-64
-       8        main    httpd       raspberrypi3-64
-       11       main    octofio     raspberrypi3-64
+       2        devel               raspberrypi4-64
+       3        main                raspberrypi4-64
+       4        main    shellhttpd  raspberrypi4-64
+       5        main    shellhttpd  raspberrypi4-64
+       6        main                raspberrypi4-64
+       7        main                raspberrypi4-64
+       8        main    httpd       raspberrypi4-64
+       11       main    octofio     raspberrypi4-64
 
 List devices
   ``fioctl devices list -f <factory>``
@@ -255,7 +255,7 @@ List devices
      $ fioctl devices list -f bebop                                                  
      NAME  FACTORY  OWNER           TARGET                  STATUS  APPS     UP TO DATE                                                                              
      ----  -------  -----           ------                  ------  ----     ----------                                                                              
-     ein   bebop    <unconfigured>  raspberrypi3-64-lmp-49  OK      netdata  true    
+     ein   bebop    <unconfigured>  raspberrypi4-64-lmp-49  OK      netdata  true    
 
 Set device tag
   ``fioctl devices config updates <device_name> --tag <tag>``

--- a/source/user-guide/foundriesio-rest-api/foundriesio-rest-api.rst
+++ b/source/user-guide/foundriesio-rest-api/foundriesio-rest-api.rst
@@ -72,10 +72,10 @@ Run:
           "owner": "5e13232f73927550af883e7b",
           "factory": "getting-started",
           "name": "device-01",
-          "created-at": "2021-11-11T14:17:50+00:00",
-          "last-seen": "2021-11-11T14:17:57+00:00",
+          "created-at": "2024-11-11T14:17:50+00:00",
+          "last-seen": "2024-11-11T14:17:57+00:00",
           "ostree-hash": "cfacf42873aa06fbf53d7b1bfcb72032f21631b068620e575696ab2ab0670efd",
-          "target-name": "raspberrypi3-64-lmp-2",
+          "target-name": "raspberrypi4-64-lmp-2",
           "current-update": "",
           "device-tags": [
             "devel"
@@ -83,7 +83,7 @@ Run:
           "tag": "devel",
           "docker-apps": [],
           "network-info": {
-            "hostname": "raspberrypi3-64",
+            "hostname": "raspberrypi4-64",
             "local_ipv4": "192.168.15.13",
             "mac": "b8:27:eb:ca:78:75"
           },
@@ -115,23 +115,23 @@ Run:
 .. code-block:: json
 
      {
-       "raspberrypi3-64-lmp-3": {
+       "raspberrypi4-64-lmp-3": {
          "custom": {
            "arch": "aarch64",
            "cliUploaded": false,
-           "createdAt": "2021-07-28T20:40:39Z",
+           "createdAt": "2025-07-28T20:40:39Z",
            "hardwareIds": [
-             "raspberrypi3-64"
+             "raspberrypi4-64"
            ],
-           "image-file": "lmp-factory-image-raspberrypi3-64.wic.gz",
+           "image-file": "lmp-factory-image-raspberrypi4-64.wic.gz",
            "lmp-manifest-sha": "b7d11e4f7d20f1fae63e1f54d8b5f48557fa40c1",
            "meta-subscriber-overrides-sha": "7de1123998c9b362df278132fde8fccb57215647",
-           "name": "raspberrypi3-64-lmp",
+           "name": "raspberrypi4-64-lmp",
            "tags": [
              "main"
            ],
            "targetFormat": "OSTREE",
-           "updatedAt": "2021-07-28T20:40:39Z",
+           "updatedAt": "2025-07-28T20:40:39Z",
            "uri": "https://ci.foundries.io/projects/getting-started/lmp/builds/3",
            "version": "3"
          },
@@ -140,23 +140,23 @@ Run:
          },
          "length": 0
        },
-       "raspberrypi3-64-lmp-2": {
+       "raspberrypi4-64-lmp-2": {
          "custom": {
            "arch": "aarch64",
            "cliUploaded": false,
-           "createdAt": "2021-07-28T20:15:29Z",
+           "createdAt": "2025-07-28T20:15:29Z",
            "hardwareIds": [
-             "raspberrypi3-64"
+             "raspberrypi4-64"
            ],
-           "image-file": "lmp-factory-image-raspberrypi3-64.wic.gz",
+           "image-file": "lmp-factory-image-raspberrypi4-64.wic.gz",
            "lmp-manifest-sha": "b6483a7b0bd666b5b871662fa46477cdeede80f2",
            "meta-subscriber-overrides-sha": "7de1123998c9b362df278132fde8fccb57215647",
-           "name": "raspberrypi3-64-lmp",
+           "name": "raspberrypi4-64-lmp",
            "tags": [
              "devel"
            ],
            "targetFormat": "OSTREE",
-           "updatedAt": "2021-07-28T20:15:29Z",
+           "updatedAt": "2025-07-28T20:15:29Z",
            "uri": "https://ci.foundries.io/projects/getting-started/lmp/builds/2",
            "version": "2"
          },
@@ -204,7 +204,7 @@ To send a configuration file named ``app.config`` to your device.
 .. code-block:: json
 
      {
-       "created-at": "2021-11-11T15:59:07",
+       "created-at": "2024-11-11T15:59:07",
        "applied-at": null,
        "reason": "API test",
        "files": [
@@ -259,7 +259,7 @@ Define the variable ``DEVICE_NAME`` and configure your device using curl_ with `
 
 .. code-block:: text
 
-     {"created-at": "2021-11-10T19:02:30", "applied-at": null, "reason": "API test", "files": [{"name": "wireguard-client", "value": "enabled=0\n\npubkey=J0H7CMG10TsTEai2Ui35KV0fb5oaJ8qd+mnWgIu091s=", "unencrypted": true}, {"name": "z-50-fioctl.toml", "on-changed": ["/usr/share/fioconfig/handlers/aktualizr-toml-update"], "value": "\n[pacman]\n  compose_apps = \"shellhttpd\"\n", "unencrypted": true}]}
+     {"created-at": "2024-11-10T19:02:30", "applied-at": null, "reason": "API test", "files": [{"name": "wireguard-client", "value": "enabled=0\n\npubkey=J0H7CMG10TsTEai2Ui35KV0fb5oaJ8qd+mnWgIu091s=", "unencrypted": true}, {"name": "z-50-fioctl.toml", "on-changed": ["/usr/share/fioconfig/handlers/aktualizr-toml-update"], "value": "\n[pacman]\n  compose_apps = \"shellhttpd\"\n", "unencrypted": true}]}
 
 Learning More About the REST API
 --------------------------------

--- a/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
+++ b/source/user-guide/lmp-auto-hostname/lmp-auto-hostname.rst
@@ -115,23 +115,23 @@ You can also check ``/etc/hostname`` to confirm the new hostname.
 
    .. group-tab:: Serial
       
-      .. prompt:: bash fio@raspberrypi3-64-51ca7875:~$
+      .. prompt:: bash fio@raspberrypi4-64-51ca7875:~$
       
           cat /etc/hostname 
       
       ::
       
-           raspberrypi3-64-51ca7875
+           raspberrypi4-64-51ca7875
       
    .. group-tab:: MAC
       
-      .. prompt:: bash fio@raspberrypi3-64-b827ebca7875:~$
+      .. prompt:: bash fio@raspberrypi4-64-b827ebca7875:~$
       
           cat /etc/hostname 
       
       ::
       
-          raspberrypi3-64-b827ebca7875
+          raspberrypi4-64-b827ebca7875
 
 .. _meta-lmp: https://github.com/foundriesio/meta-lmp/tree/main
 .. _lmp-auto-hostname: https://github.com/foundriesio/meta-lmp/tree/main/meta-lmp-base/recipes-support/lmp-auto-hostname


### PR DESCRIPTION
Removed from supported-boards CSV.
In most instances, references were updated to "raspberry pi 4". Additional changes were made in some files to address minor issues that were spotted.
Ran build, no issues, output not checked due to the number of files, and the simplicity of the changes.

This commit addresses issue FFTK-4105, "deprecate raspberrypi3 64…"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.

Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Overview

Removes/replaces rpi3 in the docs

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Avoid changing any header associated with a link/reference.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.
