### PR TITLE
Prepare docs for new theme roll-out

### DIFF
--- a/source/_static/local-dev-switcher.json
+++ b/source/_static/local-dev-switcher.json
@@ -10,9 +10,9 @@
     "preferred": true
   },
   {
-    "name": "v94",
-    "version": "94",
-    "url": "https://docs.foundries.io/94/"
+    "name": "…older",
+    "version": "",
+    "url": "https://docs.foundries.io/"
   }
 ]
 

--- a/source/_static/switcher.json
+++ b/source/_static/switcher.json
@@ -6,9 +6,9 @@
     "preferred": true
   },
   {
-    "name": "v94",
-    "version": "94",
-    "url": "https://docs.foundries.io/94/"
+    "name": "…older",
+    "version": "",
+    "url": "https://docs.foundries.io"
   }
 ]
 

--- a/source/_templates/announcement.html
+++ b/source/_templates/announcement.html
@@ -1,5 +1,3 @@
 <!-- Used by PyData Theme for announcement banner. To have no banner, set to an empty string -->
 <div class="sidebar-message">
-  For LmP v95.1 changes, please see updates to the 
-  <a href="https://github.com/foundriesio/docs/blob/main/release-notes/rn_v95.md#v951">v95 Release Notes</a>
 </div>

--- a/source/conf.py
+++ b/source/conf.py
@@ -252,7 +252,7 @@ if "dev" in release:
     if mp_tags == 'local-dev':
         json_url = '_static/local-dev-switcher.json'
     if mp_tags == 'dev':
-        json_url = '_static/switcher.json'
+        json_url = 'https://raw.githubusercontent.com/foundriesio/docs/refs/heads/next/source/_static/switcher.json'
 
 # Pydata Theme options
 html_theme_options = {


### PR DESCRIPTION
Updates to `switcher.json` made for initial publishing of the docs using the PyData theme. The announcement template has been made blank.

QA: Ran build and checked output for warnings or errors, none to report. Viewed HTML in browser to ensure correct rendering, no issues.

This commit applies to FFTK-4284, "Documentation: New theme rollout"