### PR TITLE
Add pre-req on lmp device registration page

### DIFF
--- a/source/getting-started/register-device/index.rst
+++ b/source/getting-started/register-device/index.rst
@@ -3,6 +3,10 @@
 Registering Your Device
 =======================
 
+.. important::
+   The following instructions for registering a device requires that it is running the :term:`LmP`. 
+   See :ref:`ug-flashing` for specifics on installing the LmP system image on your device.
+
 Your Linux® microPlatform (LmP) image includes the ``lmp-device-register`` tool that manages device registration for your device via the Foundries.io™ REST API.
 
 1. To register a device with your Factory, run the following **from the device console**:


### PR DESCRIPTION
Added an "important" admonition to the top of the page, clarifying that the device must be running the LmP first.

Checked rendered output and links. No issues found.

This commit addresses FFTK-4733, "Add note to device registration…"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.
You may delete items that are not relevant to your contribution.
Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)
* [ ] Merge after _date or event_
* [ ] Draft

## Checklist

* [x] Run spelling and grammar check, preferably with linter.
* [x] Step through instructions (or ask someone to do so).
* [x] Review for [wordiness](https://languagetool.org/insights/post/wordiness/)
* [x] Match tone and style of page/section.
* [x] Run `make linkcheck`, and add redirects for any moved or deleted pages.
* [x] View HTML in a browser to check rendering.
* [x] Use [semantic newlines](https://bobheadxi.dev/semantic-line-breaks/).
* [x] follow best practices for commits.
  * [x] Descriptive title written in the imperative.
  * [x] Include brief overview of QA steps taken.
  * [x] Mention any related issues numbers.
  * [x] End message with sign off/DCO line (`-s, --signoff`).
  * [x] Sign commit with your gpg key (`-S, --gpg-sign`).
  * [x] Squash commits if needed.
* [x] Request PR review by a technical writer and at least one peer.
