### PR TITLE
Fix issues around fioctl_version

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Add latest Fioctl docs
         run: |
-          export fv=$(wget -q -O- https://api.github.com/repos/foundriesio/fioctl/releases/latest | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/')
-          wget -O /tmp/fioctl https://github.com/foundriesio/fioctl/releases/download/${fv}/fioctl-linux-amd64
+          wget -O /tmp/fioctl https://github.com/foundriesio/fioctl/releases/latest/download/fioctl-linux-amd64
           chmod +x /tmp/fioctl
           /tmp/fioctl gen-rst source/appendix/fioctl-command-reference/
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Add latest Fioctl docs
         run: |
-          export fv=$(wget -q -O- https://api.github.com/repos/foundriesio/fioctl/releases/latest | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/')
-          wget -O /tmp/fioctl https://github.com/foundriesio/fioctl/releases/download/${fv}/fioctl-linux-amd64
+          wget -O /tmp/fioctl https://github.com/foundriesio/fioctl/releases/latest/download/fioctl-linux-amd64
           chmod +x /tmp/fioctl
           /tmp/fioctl gen-rst source/appendix/fioctl-command-reference/
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -19,7 +19,6 @@ from urllib.request import urlopen
 
 mp_version = os.environ.get('MP_UPDATE_VERSION')
 lmp_build = os.environ.get('LMP_BUILD')
-fioctl_version = os.environ.get('fv')
 if mp_version is None:
     try:
         git_version = subprocess.check_output(['git', 'describe', '--tags'])
@@ -213,8 +212,7 @@ exclude_patterns = ['user-guide/flashing/*-flashing.rst',
 rst_epilog = '''
 .. |docker_tag| replace:: {}
 .. |manifest_tag| replace:: {}
-.. |fioctl_version| replace:: {}
-'''.format(docker_tag, manifest_tag, fioctl_version)
+'''.format(docker_tag, manifest_tag)
 
 # -- PDF Configuration --------------------------------------------------------
 

--- a/source/getting-started/install-fioctl/index.rst
+++ b/source/getting-started/install-fioctl/index.rst
@@ -47,17 +47,13 @@ We use `GitHub Releases`_ to distribute static golang binaries.
         .. attention:: Make sure you have ``curl`` installed.
 
         1. Download a Linux binary to a directory on your ``PATH``.
-           For example, to download version |fioctl_version| on Linux, define the version:
-
-           .. parsed-literal::
-
-              FIOCTL_VERSION="|fioctl_version|"
+           For example, to download the latest version on Linux:
 
            Download the binary with curl:
 
            .. code-block:: console
 
-              $ sudo curl -o /usr/local/bin/fioctl -LO https://github.com/foundriesio/fioctl/releases/download/$FIOCTL_VERSION/fioctl-linux-amd64
+              $ sudo curl -o /usr/local/bin/fioctl -LO https://github.com/foundriesio/fioctl/releases/latest/download/fioctl-linux-amd64
 
         2. Make the :ref:`ref-fioctl` binary executable:
 
@@ -73,21 +69,17 @@ We use `GitHub Releases`_ to distribute static golang binaries.
 
         1. Download a Darwin binary from the `GitHub Releases`_ page to a directory on your ``PATH``.
 
-           For example, to download version |fioctl_version| on macOS, define the version:
-
-           .. parsed-literal::
-
-                FIOCTL_VERSION="|fioctl_version|"
+           For example, to download the latest version on macOS:
 
            Download the binary with curl:
 
            .. code-block:: console
 
-              $ sudo curl -o /usr/local/bin/fioctl -L https://github.com/foundriesio/fioctl/releases/download/$FIOCTL_VERSION/fioctl-darwin-amd64
+              $ sudo curl -o /usr/local/bin/fioctl -L https://github.com/foundriesio/fioctl/releases/latest/download/fioctl-darwin-amd64
 
            .. important::
 
-              For MacOS running on a Apple M1 processor, replace ``fioctl-darwin-amd64`` with ``fioctl-darwin-arm64``, and set ``FIOCTL_VERSION`` to v0.21 or newer.
+              For MacOS running on a Apple M1 processor, replace ``fioctl-darwin-amd64`` with ``fioctl-darwin-arm64``.
 
         2. Make the :ref:`ref-fioctl` binary executable:
 


### PR DESCRIPTION
Fixes included adding an `export` to the fioctl install steps, adding the fioctl version to the GitHub envars in the workflow files so that it is available for the doc builds, and adding a case where it isn't passed to default to `latest`.

This commit addresses issue FFTK-4779, "fix fioctl version…"

# PR Template and Checklist

Please complete as much as possible to speed up the reviewing process.
You may delete items that are not relevant to your contribution.
Readiness and adding reviewers as appropriate is required.

All PRs should be reviewed by a technical writer/documentation team and a peer.
If effecting customers—which is a majority of content changes—a member of Customer Success must also review.

## Readiness

* [x] Merge (pending reviews)